### PR TITLE
feat: add merge conflict label action

### DIFF
--- a/github-api/src/lib.rs
+++ b/github-api/src/lib.rs
@@ -3,6 +3,7 @@ pub mod error;
 mod github_provider;
 mod macros;
 pub mod models;
+pub mod models_plus;
 pub mod provider_traits;
 pub mod webhooks;
 pub mod wrappers;

--- a/github-api/src/models_plus/mod.rs
+++ b/github-api/src/models_plus/mod.rs
@@ -1,0 +1,4 @@
+//! This module provides additional functionality and helper functions to the structs in the `models` module.
+//! The code is kept separate to avoid messing with the code generation tools.
+
+mod pull_request;

--- a/github-api/src/models_plus/pull_request.rs
+++ b/github-api/src/models_plus/pull_request.rs
@@ -1,0 +1,7 @@
+use crate::models::PullRequest;
+
+impl PullRequest {
+    pub fn has_merge_conflicts(&self) -> bool {
+        matches!(self.mergeable, Some(false)) && !matches!(self.merged, Some(true))
+    }
+}

--- a/server/src/actions/essentials.rs
+++ b/server/src/actions/essentials.rs
@@ -98,6 +98,11 @@ impl GithubActionBuilder {
         self
     }
 
+    pub fn label_conflicts(mut self) -> Self {
+        self.params = Some(GithubActionParams::check_conflicts());
+        self
+    }
+
     pub fn build(self) -> Actions {
         match self.params {
             None => {
@@ -154,6 +159,16 @@ mod test {
         match action {
             Actions::NullAction => (),
             _ => panic!("Expected a null action"),
+        }
+    }
+
+    #[test]
+    fn test_github_action_builder_conflicts() {
+        let action = Actions::github().label_conflicts().build();
+
+        match action {
+            Actions::Github(p) => assert_eq!(*p, GithubActionParams::CheckConflicts),
+            _ => panic!("Expected a CheckConflicts action"),
         }
     }
 }

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -62,6 +62,13 @@ mod rules {
                 .when(PullRequest::poor_justification())
                 .execute(Actions::github().add_label("CR-insufficient_context").build())
                 .submit(),
+            RuleBuilder::new("Merge conflict check")
+                .when(PullRequest::opened())
+                .when(PullRequest::reopened())
+                .when(PullRequest::synchronize())
+                .when(PullRequest::edited())
+                .execute(Actions::github().label_conflicts().build())
+                .submit(),
             {
                 let action = Actions::closure()
                     .with(|name, event| {


### PR DESCRIPTION
This PR adds an addional Github action that will add or remove the
`P-conflict` label if the PR is in a merge-conflict state.

A rule to check this status on every update to PRs has also been added.