### PR TITLE
feat: add if_exists check to remove_label

### DIFF
--- a/cli/src/issue.rs
+++ b/cli/src/issue.rs
@@ -23,7 +23,7 @@ pub async fn run_issue_cmd(
             Ok(_) => info!("{} added to issue {}/{}", l.label, id.repo, id.number),
             Err(e) => warn!("Error adding label to issue: {}", e.to_string()),
         },
-        IssueCommand::RemoveLabel(l) => match provider.remove_label(&id, l.label.as_str()).await {
+        IssueCommand::RemoveLabel(l) => match provider.remove_label(&id, l.label.as_str(), false).await {
             Ok(_) => info!("{} removed from issue {}/{}", l.label, id.repo, id.number),
             Err(e) => warn!("Error removing label from issue: {}", e.to_string()),
         },

--- a/github-api/src/api/issue.rs
+++ b/github-api/src/api/issue.rs
@@ -63,4 +63,9 @@ impl IssueRequest {
         let req = proxy.delete(self.remove_label_path(label).as_str());
         proxy.send(req).await
     }
+
+    pub async fn fetch_labels(&self, proxy: &ClientProxy) -> Result<Vec<Label>, GithubApiError> {
+        let req = proxy.get(self.add_label_path().as_str(), false);
+        proxy.send(req).await
+    }
 }

--- a/github-api/src/provider_traits/issue_provider.rs
+++ b/github-api/src/provider_traits/issue_provider.rs
@@ -12,5 +12,7 @@ pub trait IssueProvider {
 
     async fn add_label(&self, id: &IssueId, label: &str) -> Result<Vec<Label>, GithubProviderError>;
 
-    async fn remove_label(&self, id: &IssueId, label: &str) -> Result<Vec<Label>, GithubProviderError>;
+    async fn remove_label(&self, id: &IssueId, label: &str, only_if_exists: bool) -> Result<(), GithubProviderError>;
+
+    async fn label_exists(&self, label: &str, id: &IssueId) -> Result<bool, GithubProviderError>;
 }

--- a/server/src/actions/github_action.rs
+++ b/server/src/actions/github_action.rs
@@ -152,7 +152,7 @@ impl Handler<GithubActionMessage> for GithubActionExecutor {
                         label, owner, repo, issue_number
                     );
                     let req = IssueId::new(owner, repo, issue_number);
-                    let res = provider.remove_label(&req, label).await;
+                    let res = provider.remove_label(&req, label, false).await;
                     if let Err(e) = res {
                         warn!("Failed to remove label to issue: {}", e.to_string());
                     }
@@ -174,7 +174,7 @@ impl Handler<GithubActionMessage> for GithubActionExecutor {
                     let pr_number = event.number();
                     debug!("Removing label {} from PR {}/{}#{}", label, owner, repo, pr_number);
                     let req = IssueId::new(owner, repo, pr_number);
-                    let res = provider.remove_label(&req, label).await;
+                    let res = provider.remove_label(&req, label, false).await;
                     if let Err(e) = res {
                         warn!("Failed to remove label from PR: {}", e.to_string());
                     }
@@ -188,9 +188,9 @@ impl Handler<GithubActionMessage> for GithubActionExecutor {
                     let conflict_label = "P-conflicts";
                     let pr = event.pull_request();
                     let res = if pr.has_merge_conflicts() {
-                        provider.add_label(&req, conflict_label).await
+                        provider.add_label(&req, conflict_label).await.map(|_| ())
                     } else {
-                        provider.remove_label(&req, conflict_label).await
+                        provider.remove_label(&req, conflict_label, true).await
                     };
                     if let Err(e) = res {
                         warn!("Failed to add/remove conflict label to/from PR: {}", e.to_string());


### PR DESCRIPTION
If you try remove a non-existent label, github returns a 404, which isn't great for hygiene. So

- accept a `only_if_exists` flag to remove_label
- add a fetch_labels call in support
- update merge_conflict action to check for existence first