### PR TITLE
feat: tidy up logs on merge conflict action

### DIFF
--- a/cli/src/issue.rs
+++ b/cli/src/issue.rs
@@ -20,11 +20,12 @@ pub async fn run_issue_cmd(
             Err(e) => warn!("Error fetching issue: {}", e.to_string()),
         },
         IssueCommand::AddLabel(l) => match provider.add_label(&id, l.label.as_str()).await {
-            Ok(_) => info!("{} added to issue {}/{}", l.label, id.repo, id.number),
+            Ok(_) => info!("🏷 '{}' added to issue {}/{}", l.label, id.repo, id.number),
             Err(e) => warn!("Error adding label to issue: {}", e.to_string()),
         },
         IssueCommand::RemoveLabel(l) => match provider.remove_label(&id, l.label.as_str(), false).await {
-            Ok(_) => info!("{} removed from issue {}/{}", l.label, id.repo, id.number),
+            Ok(true) => info!("🏷 '{}' removed from issue {}/{}", l.label, id.repo, id.number),
+            Ok(false) => info!("🏷 '{}' was not present on issue {}/{}", l.label, id.repo, id.number),
             Err(e) => warn!("Error removing label from issue: {}", e.to_string()),
         },
     }

--- a/github-api/src/github_provider.rs
+++ b/github-api/src/github_provider.rs
@@ -91,12 +91,18 @@ impl IssueProvider for GithubProvider {
         Ok(labels)
     }
 
-    async fn remove_label(&self, id: &IssueId, label: &str, only_if_exists: bool) -> Result<(), GithubProviderError> {
+    /// Remove a label from an issue.
+    ///
+    /// The boolean result indicates whether a call to the API to remove the label was actually made.
+    /// e.g., if the label was not present on the issue, then no call was made, and the result is `false`.
+    async fn remove_label(&self, id: &IssueId, label: &str, only_if_exists: bool) -> Result<bool, GithubProviderError> {
         let issue = IssueRequest::new(&id.owner, &id.repo, id.number);
         if !only_if_exists || self.label_exists(label, id).await? {
             let _labels = issue.remove_label(label, &self.client).await?;
+            Ok(true)
+        } else {
+            Ok(false)
         }
-        Ok(())
     }
 
     async fn label_exists(&self, label: &str, id: &IssueId) -> Result<bool, GithubProviderError> {

--- a/github-api/src/provider_traits/issue_provider.rs
+++ b/github-api/src/provider_traits/issue_provider.rs
@@ -12,7 +12,7 @@ pub trait IssueProvider {
 
     async fn add_label(&self, id: &IssueId, label: &str) -> Result<Vec<Label>, GithubProviderError>;
 
-    async fn remove_label(&self, id: &IssueId, label: &str, only_if_exists: bool) -> Result<(), GithubProviderError>;
+    async fn remove_label(&self, id: &IssueId, label: &str, only_if_exists: bool) -> Result<bool, GithubProviderError>;
 
     async fn label_exists(&self, label: &str, id: &IssueId) -> Result<bool, GithubProviderError>;
 }


### PR DESCRIPTION
Report more details, by returning whether we hit the APi to remove the label or not.

Prettier log messages.