### PR TITLE
refactor(logs): add emojis to logs to make 'em prettier

### DIFF
--- a/cli/src/issue.rs
+++ b/cli/src/issue.rs
@@ -17,16 +17,16 @@ pub async fn run_issue_cmd(
     match cmd {
         IssueCommand::Fetch => match provider.fetch_issue(&id).await {
             Ok(issue) => pretty_print(issue),
-            Err(e) => warn!("Error fetching issue: {}", e.to_string()),
+            Err(e) => warn!("📒 Error fetching issue: {}", e.to_string()),
         },
         IssueCommand::AddLabel(l) => match provider.add_label(&id, l.label.as_str()).await {
             Ok(_) => info!("🏷 '{}' added to issue {}/{}", l.label, id.repo, id.number),
-            Err(e) => warn!("Error adding label to issue: {}", e.to_string()),
+            Err(e) => warn!("🏷 Error adding label to issue: {}", e.to_string()),
         },
         IssueCommand::RemoveLabel(l) => match provider.remove_label(&id, l.label.as_str(), false).await {
             Ok(true) => info!("🏷 '{}' removed from issue {}/{}", l.label, id.repo, id.number),
             Ok(false) => info!("🏷 '{}' was not present on issue {}/{}", l.label, id.repo, id.number),
-            Err(e) => warn!("Error removing label from issue: {}", e.to_string()),
+            Err(e) => warn!("🏷 Error removing label from issue: {}", e.to_string()),
         },
     }
     Ok(())

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -28,19 +28,19 @@ async fn main() -> Result<(), ()> {
 fn setup_github_api(cli: &Cli) -> GithubProvider {
     match (cli.user_name.as_ref(), cli.auth_token.as_ref()) {
         (Some(u), Some(a)) => {
-            info!("Ignition! Launching Github Pilot in Authenticated Mode.");
+            info!("🚀 Ignition! Launching Github Pilot in Authenticated Mode.");
             GithubProvider::new(u.as_str(), a.as_str())
         },
         (Some(_), None) => {
-            warn!("Username was set, but auth token was not provided. Defaulting to unauthenticated mode");
+            warn!("🚀 Username was set, but auth token was not provided. Defaulting to unauthenticated mode");
             GithubProvider::default()
         },
         (None, Some(_)) => {
-            warn!("Auth token was set, but username was not provided. Defaulting to unauthenticated mode");
+            warn!("🚀 Auth token was set, but username was not provided. Defaulting to unauthenticated mode");
             GithubProvider::default()
         },
         (None, None) => {
-            info!("No credentials provided. Launching Github Pilot in unauthenticated mode.");
+            info!("🚀 No credentials provided. Launching Github Pilot in unauthenticated mode.");
             GithubProvider::default()
         },
     }

--- a/cli/src/pull_request.rs
+++ b/cli/src/pull_request.rs
@@ -6,7 +6,7 @@ use crate::pretty_print::{add_labels, pretty_table};
 pub async fn run_pr_cmd(provider: &dyn PullRequestProvider, owner: &str, repo: &str, number: u64) -> Result<(), ()> {
     match provider.fetch_pull_request(owner, repo, number).await {
         Ok(pr) => pretty_print(pr),
-        Err(e) => warn!("Error fetching pr: {}", e.to_string()),
+        Err(e) => warn!("⏩ Error fetching PR: {}", e.to_string()),
     }
     Ok(())
 }

--- a/cli/src/user.rs
+++ b/cli/src/user.rs
@@ -3,12 +3,12 @@ use github_pilot_api::{models::SimpleUser, provider_traits::UserProvider, wrappe
 use log::*;
 
 pub async fn run_user_cmd<S: AsRef<str>>(provider: &dyn UserProvider, profile: S) -> Result<(), ()> {
-    debug!("Fetching user..{}", profile.as_ref());
+    debug!("👨 Fetching user..{}", profile.as_ref());
     let handle = GithubHandle::from(profile.as_ref());
     let details = provider.fetch_details(&handle).await.map_err(|_| ())?;
     match details {
         Some(p) => pretty_print(&p),
-        None => info!("User {} was not found", profile.as_ref()),
+        None => info!("👨 User {} was not found", profile.as_ref()),
     }
     Ok(())
 }

--- a/github-api/src/github_provider.rs
+++ b/github-api/src/github_provider.rs
@@ -25,7 +25,7 @@ impl Default for GithubProvider {
     fn default() -> Self {
         GithubProvider::from_environment().unwrap_or_else(|err| {
             warn!(
-                "Could not create default Github Provider instance using environment variables. {}. Setting \
+                "🐙 Could not create default Github Provider instance using environment variables. {}. Setting \
                  credentials to blank (and almost certainly incorrect) values.",
                 err.to_string()
             );

--- a/server/src/actions/closure_action.rs
+++ b/server/src/actions/closure_action.rs
@@ -66,7 +66,7 @@ impl Supervised for ClosureActionExecutor {}
 
 impl SystemService for ClosureActionExecutor {
     fn service_started(&mut self, _ctx: &mut Context<Self>) {
-        debug!("Closure Action Service is running.");
+        debug!("📝 Closure Action Service is running.");
     }
 }
 
@@ -74,16 +74,16 @@ impl Actor for ClosureActionExecutor {
     type Context = Context<Self>;
 
     fn started(&mut self, _ctx: &mut Self::Context) {
-        debug!("Closure Action actor has started.");
+        debug!("📝 Closure Action actor has started.");
     }
 
     fn stopping(&mut self, _ctx: &mut Self::Context) -> Running {
-        debug!("Closure Action actor is stopping.");
+        debug!("📝 Closure Action actor is stopping.");
         Running::Stop
     }
 
     fn stopped(&mut self, _ctx: &mut Self::Context) {
-        debug!("Closure Action actor has stopped.");
+        debug!("📝 Closure Action actor has stopped.");
     }
 }
 
@@ -92,19 +92,19 @@ impl Handler<ClosureActionMessage> for ClosureActionExecutor {
 
     fn handle(&mut self, msg: ClosureActionMessage, _ctx: &mut Self::Context) -> Self::Result {
         let (name, event_name, event, action) = msg.to_parts();
-        debug!("Starting task \"{}\" for \"{}\"", name, event_name);
+        debug!("📝 Starting task \"{}\" for \"{}\"", name, event_name);
         Box::pin(async move {
-            debug!("Running closure action");
+            debug!("📝 Running closure action");
             let f = action.function;
             let result = tokio::task::spawn_blocking(move || {
                 f(event_name, event);
             })
             .await;
             match result {
-                Ok(()) => debug!("Closure Task completely happily."),
-                Err(e) => debug!("Closure task wasn't happy. {}", e.to_string()),
+                Ok(()) => debug!("📝 Closure Task completely happily."),
+                Err(e) => debug!("📝 Closure task wasn't happy. {}", e.to_string()),
             }
-            debug!("Completed execution of task \"{}\"", name);
+            debug!("📝 Completed execution of task \"{}\"", name);
         })
     }
 }

--- a/server/src/actions/github_action.rs
+++ b/server/src/actions/github_action.rs
@@ -26,7 +26,7 @@ use github_pilot_api::{
     wrappers::IssueId,
     GithubProvider,
 };
-use log::{debug, info, warn};
+use log::*;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum GithubActionParams {
@@ -109,7 +109,7 @@ impl Supervised for GithubActionExecutor {}
 
 impl SystemService for GithubActionExecutor {
     fn service_started(&mut self, _ctx: &mut Context<Self>) {
-        debug!("Github Action Executor service has started");
+        debug!("🐙 Github Action Executor service has started");
     }
 }
 
@@ -117,16 +117,16 @@ impl Actor for GithubActionExecutor {
     type Context = Context<Self>;
 
     fn started(&mut self, _ctx: &mut Self::Context) {
-        println!("Github Action Executor has started");
+        debug!("🐙 Github Action Executor has started");
     }
 
     fn stopping(&mut self, _ctx: &mut Self::Context) -> Running {
-        println!("Github Action Executor is stopping");
+        println!("🐙 Github Action Executor is stopping");
         Running::Stop
     }
 
     fn stopped(&mut self, _ctx: &mut Self::Context) {
-        println!("Github Action Executor has stopped");
+        println!("🐙 Github Action Executor has stopped");
     }
 }
 
@@ -153,7 +153,7 @@ impl Handler<GithubActionMessage> for GithubActionExecutor {
                     Self::check_and_label_merge_conflicts(provider, event).await
                 },
                 _ => {
-                    warn!("Unimplemented event type for Github Action: {}", msg.event_name());
+                    warn!("🐙 Unimplemented event type for Github Action: {}", msg.event_name());
                 },
             }
         };
@@ -166,11 +166,14 @@ impl GithubActionExecutor {
         let repo = event.repo();
         let owner = event.owner();
         let issue_number = event.number();
-        debug!("Adding label {} to issue {}/{}#{}", label, owner, repo, issue_number);
+        debug!(
+            "🐙🏷 Adding label {} to issue {}/{}#{}",
+            label, owner, repo, issue_number
+        );
         let req = IssueId::new(owner, repo, issue_number);
         let res = provider.add_label(&req, label).await;
         if let Err(e) = res {
-            warn!("Failed to add label to issue: {}", e.to_string());
+            warn!("🐙🏷 Failed to add label to issue: {}", e.to_string());
         }
     }
 
@@ -179,18 +182,18 @@ impl GithubActionExecutor {
         let owner = event.owner();
         let issue_number = event.number();
         debug!(
-            "Removing label {} from issue {}/{}#{}",
+            "🐙🏷 Removing label {} from issue {}/{}#{}",
             label, owner, repo, issue_number
         );
         let req = IssueId::new(owner, repo, issue_number);
         match provider.remove_label(&req, label, false).await {
-            Ok(true) => info!("🏷 '{}' removed from issue {}/{}#{}", label, owner, repo, issue_number),
+            Ok(true) => info!("🐙🏷 '{}' removed from issue {}/{}#{}", label, owner, repo, issue_number),
             Ok(false) => info!(
-                "🏷 '{}' not found on issue {}/{}#{}, so nothing to remove 😏",
+                "🐙🏷 '{}' not found on issue {}/{}#{}, so nothing to remove 😏",
                 label, owner, repo, issue_number
             ),
             Err(e) => warn!(
-                "🏷 '{}' removal failed on issue {}/{}#{}. {}",
+                "🐙🏷 '{}' removal failed on issue {}/{}#{}. {}",
                 label, owner, repo, issue_number, e
             ),
         }
@@ -200,11 +203,11 @@ impl GithubActionExecutor {
         let repo = event.repo();
         let owner = event.owner();
         let pr_number = event.number();
-        debug!("Adding label {} to PR {}/{}#{}", label, owner, repo, pr_number);
+        debug!("🐙🏷 Adding label {} to PR {}/{}#{}", label, owner, repo, pr_number);
         let req = IssueId::new(owner, repo, pr_number);
         let res = provider.add_label(&req, label).await;
         if let Err(e) = res {
-            warn!("Failed to add label to PR: {}", e.to_string());
+            warn!("🐙🏷 Failed to add label to PR: {}", e.to_string());
         }
     }
 
@@ -212,16 +215,16 @@ impl GithubActionExecutor {
         let repo = event.repo();
         let owner = event.owner();
         let pr_number = event.number();
-        debug!("Removing label {} from PR {}/{}#{}", label, owner, repo, pr_number);
+        debug!("🐙🏷 Removing label {} from PR {}/{}#{}", label, owner, repo, pr_number);
         let req = IssueId::new(owner, repo, pr_number);
         match provider.remove_label(&req, label, false).await {
-            Ok(true) => info!("🏷 '{}' removed from PR {}/{}#{}", label, owner, repo, pr_number),
+            Ok(true) => info!("🐙🏷 '{}' removed from PR {}/{}#{}", label, owner, repo, pr_number),
             Ok(false) => info!(
-                "🏷 '{}' not found on PR {}/{}#{}, so nothing to remove 😏",
+                "🐙🏷 '{}' not found on PR {}/{}#{}, so nothing to remove 😏",
                 label, owner, repo, pr_number
             ),
             Err(e) => warn!(
-                "🏷 '{}' removal failed on PR: {}/{}#{}. {}",
+                "🐙🏷 '{}' removal failed on PR: {}/{}#{}. {}",
                 label, owner, repo, pr_number, e
             ),
         }
@@ -232,12 +235,15 @@ impl GithubActionExecutor {
         let owner = event.owner();
         let pr_number = event.number();
         let req = IssueId::new(owner, repo, pr_number);
-        debug!("Checking merge conflict status for PR {}/{}#{}", owner, repo, pr_number);
+        debug!(
+            "🐙🤺 Checking merge conflict status for PR {}/{}#{}",
+            owner, repo, pr_number
+        );
         let conflict_label = "P-conflicts";
         let pr = event.pull_request();
         let res = if pr.has_merge_conflicts() {
             info!(
-                "PR {}/{}#{} has merge conflicts. {} label added",
+                "🐙🤺 PR {}/{}#{} has merge conflicts. {} label added",
                 owner, repo, pr_number, conflict_label
             );
             provider.add_label(&req, conflict_label).await.map(|_| ())
@@ -245,15 +251,15 @@ impl GithubActionExecutor {
             match provider.remove_label(&req, conflict_label, true).await {
                 Ok(true) => {
                     info!(
-                        "🤺 Merge conflicts resolved on PR {}/{}#{}. Label removed.",
+                        "🐙🤺 Merge conflicts resolved on PR {}/{}#{}. Label removed.",
                         owner, repo, pr_number
                     );
                     Ok(())
                 },
                 Ok(false) => {
-                    debug!(
-                        "Merge conflict label wasn't attached to the PR. There likely weren't merge conflicts in the \
-                         first place"
+                    trace!(
+                        "🐙🤺 Merge conflict label wasn't attached to the PR. There likely weren't merge conflicts in \
+                         the first place"
                     );
                     Ok(())
                 },
@@ -262,7 +268,7 @@ impl GithubActionExecutor {
         };
         if let Err(e) = res {
             warn!(
-                "🤺 Merge conflict status update failed on PR: {}/{}#{}. {}",
+                "🐙🤺 Merge conflict status update failed on PR: {}/{}#{}. {}",
                 owner, repo, pr_number, e
             );
         }

--- a/server/src/heuristics/pull_requests.rs
+++ b/server/src/heuristics/pull_requests.rs
@@ -28,7 +28,7 @@ impl<'pr> PullRequestHeuristics<'pr> {
         } else {
             PullRequestSize::Huge
         };
-        trace!("PR size heuristic: {:?}", size);
+        trace!("🐙⛰ PR size heuristic: {:?}", size);
         size
     }
 
@@ -47,7 +47,7 @@ impl<'pr> PullRequestHeuristics<'pr> {
         let commit_count = self.pr.commits.unwrap_or(2) as f64;
         let files_changed = self.pr.changed_files.unwrap_or(1) as f64;
         let complexity = complexity_heuristic(additions, deletions, commit_count, files_changed);
-        trace!("PR complexity heuristic: {:?}", complexity);
+        trace!("🐙⛰ PR complexity heuristic: {:?}", complexity);
         complexity
     }
 
@@ -74,7 +74,7 @@ fn complexity_heuristic(
     // But the total number of changes is important too.
     let size_complexity = total.powf(1.25) / (additions.abs_diff(deletions).max(10) as f64).sqrt();
     let complexity_score = 3.0 * commit_count + 1.5 * files_changed + size_complexity;
-    trace!("Complexity score: {}", complexity_score);
+    trace!("🐙⛰ Complexity score: {}", complexity_score);
     match complexity_score as usize {
         0..=20 => PullRequestComplexity::Low,
         21..=250 => PullRequestComplexity::Medium,

--- a/server/src/predicates/pull_request.rs
+++ b/server/src/predicates/pull_request.rs
@@ -203,7 +203,7 @@ impl RulePredicate for PullRequest {
             action, pull_request, ..
         }) = event.event()
         {
-            trace!("testing {:?} against event {}/{}", self.trigger, event.name(), action);
+            trace!("❓testing {:?} against event {}/{}", self.trigger, event.name(), action);
             let heuristic = PullRequestHeuristics::new(pull_request);
             match (&self.trigger, action) {
                 (PullRequestPredicate::Assigned(None), PullRequestAction::Assigned { .. }) => true,

--- a/server/src/pub_sub/actor.rs
+++ b/server/src/pub_sub/actor.rs
@@ -58,7 +58,7 @@ impl PubSubActor {
             Actions::Closure(c) => self.dispatch_closure_action(*c.clone(), event_name, event),
             Actions::Github(a) => self.dispatch_github_action(*a.clone(), event_name, event),
             Actions::NullAction => {
-                info!("NullAction was dispatched. Doing nothing");
+                info!("📰 NullAction was dispatched. Doing nothing");
                 Ok(())
             },
         }
@@ -97,16 +97,16 @@ impl Actor for PubSubActor {
     type Context = Context<Self>;
 
     fn started(&mut self, _ctx: &mut Self::Context) {
-        debug!("PubSub actor has started.");
+        debug!("📰 PubSub actor has started.");
     }
 
     fn stopping(&mut self, _ctx: &mut Self::Context) -> Running {
-        debug!("PubSub actor is stopping.");
+        debug!("📰 PubSub actor is stopping.");
         Running::Stop
     }
 
     fn stopped(&mut self, _ctx: &mut Self::Context) {
-        debug!("PubSub actor has stopped.");
+        debug!("📰 PubSub actor has stopped.");
     }
 }
 
@@ -114,11 +114,11 @@ impl Handler<GithubEventMessage> for PubSubActor {
     type Result = ();
 
     fn handle(&mut self, msg: GithubEventMessage, _ctx: &mut Self::Context) -> Self::Result {
-        trace!("PubSub received github event message: {}", msg.name());
+        trace!("📰 PubSub received github event message: {}", msg.name());
         let rules = self.rules.read();
         // FIXME: Return an error properly
         if rules.is_err() {
-            warn!("Could not access rules. {}", rules.err().unwrap().to_string());
+            warn!("📰 Could not access rules. {}", rules.err().unwrap().to_string());
             return;
         }
         let rules = rules.unwrap();
@@ -131,21 +131,21 @@ impl Handler<GithubEventMessage> for PubSubActor {
             if rule_triggered.is_some() {
                 rules_matched += 1;
                 info!(
-                    "Rule \"{}\" triggered for \"{}\". Running its actions.",
+                    "📰 Rule \"{}\" triggered for \"{}\". Running its actions.",
                     rule.name(),
                     msg.name()
                 );
                 let name = format!("{}-{}.{}", rule.name(), event_name, timestamp());
                 for action in rule.actions().cloned() {
-                    trace!("Preparing task \"{}\"", name);
+                    trace!("📰 Preparing task \"{}\"", name);
                     let dispatch_result = self.dispatch_message(action, event_name.clone(), event.clone());
                     if let Err(e) = dispatch_result {
-                        warn!("There was an issue dispatching {}: {}", name, e.to_string());
+                        warn!("📰 There was an issue dispatching {}: {}", name, e.to_string());
                     }
                 }
             }
         }
-        debug!("{} rules matched event \"{}\"", rules_matched, event_name);
+        debug!("📰 {} rules matched event \"{}\"", rules_matched, event_name);
     }
 }
 

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -15,7 +15,7 @@ pub async fn run_server(config: ServerConfig) -> Result<(), ServerError> {
     let pubsub = PubSubActor::new().start();
 
     let num_rules = rules::load_rules(pubsub.clone()).await?;
-    info!("{} Rules loaded", num_rules);
+    info!("📄 {} Rules loaded", num_rules);
 
     HttpServer::new(move || {
         App::new()
@@ -73,7 +73,7 @@ mod rules {
                 let action = Actions::closure()
                     .with(|name, event| {
                         let pr = event.pull_request().unwrap();
-                        let label = if let PullRequestAction::Unlabeled { label } = &pr.action {
+                        let label = if let PullRequestAction::Labeled { label } = &pr.action {
                             label.name.as_str()
                         } else {
                             "?"


### PR DESCRIPTION
Put emoji prefixes in log messages to make it easier to pick them out in the log noise (eps on TRACE level).