### PR TITLE
feat: add labels from yml files to repo

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -7,9 +7,11 @@ description = "A command line interface for GitHub Pages; intended as a client p
 
 [dependencies]
 github-pilot-api = { version = "0.1", path = "../github-api" }
+
 clap = {version = "3.2.16", features = ["derive", "env"] }
 comfy-table = "6.0.0"
-tokio = {version = "1.20.1", features = ["full"] }
+env_logger = "0.9.0"
 hex = "0.4.3"
 log = "0.4.17"
-env_logger = "0.9.0"
+serde_yaml = "0.9.13"
+tokio = {version = "1.20.1", features = ["full"] }

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -13,5 +13,6 @@ comfy-table = "6.0.0"
 env_logger = "0.9.0"
 hex = "0.4.3"
 log = "0.4.17"
+serde_json = "1.0.70"
 serde_yaml = "0.9.13"
 tokio = {version = "1.20.1", features = ["full"] }

--- a/cli/src/cli_def.rs
+++ b/cli/src/cli_def.rs
@@ -37,6 +37,63 @@ pub enum Commands {
         #[clap(subcommand)]
         sub_command: IssueCommand,
     },
+    /// Manipulate labels on a repo
+    Labels {
+        #[clap(subcommand)]
+        sub_command: LabelCommand,
+    },
+}
+
+#[derive(Debug, Subcommand)]
+pub enum LabelCommand {
+    /// List all labels on a repo
+    #[clap(name = "list")]
+    List {
+        /// The page number to fetch
+        #[clap(short, long)]
+        page: Option<usize>,
+        /// The number of labels to fetch per page
+        #[clap(short = 'n', long)]
+        per_page: Option<usize>,
+    },
+    /// Create a new label
+    Create {
+        /// The name of the label
+        #[clap(short, long)]
+        name: String,
+        /// The color of the label
+        #[clap(short, long)]
+        color: Option<String>,
+        /// The description of the label
+        #[clap(short, long)]
+        description: Option<String>,
+    },
+    /// Delete a label
+    Delete {
+        /// The name of the label
+        #[clap(short, long)]
+        label: String,
+    },
+    /// Assign labels to a repo
+    Assign {
+        /// A path to a file containing label definitions
+        labels_file: String,
+    },
+    /// Edit an existing label
+    Edit {
+        /// The name of the label
+        #[clap(short, long)]
+        label: String,
+        /// The new name of the label
+        #[clap(short, long)]
+        name: Option<String>,
+        /// The new color of the label
+        #[clap(short, long)]
+        color: Option<String>,
+        /// The new description of the label
+        #[clap(short, long)]
+        description: Option<String>,
+    },
 }
 
 #[derive(Debug, Subcommand)]

--- a/cli/src/cli_def.rs
+++ b/cli/src/cli_def.rs
@@ -85,6 +85,7 @@ pub enum LabelCommand {
     #[clap(name = "assign")]
     Assign {
         /// A path to a file containing label definitions
+        #[clap(short = 'f', long = "file")]
         labels_file: String,
     },
     /// Edit an existing label

--- a/cli/src/cli_def.rs
+++ b/cli/src/cli_def.rs
@@ -1,4 +1,6 @@
-use clap::{Args, Parser, Subcommand};
+use std::fmt::Display;
+
+use clap::{Args, Parser, Subcommand, ValueEnum};
 
 #[derive(Parser, Debug)]
 #[clap(author, version, about, long_about = None)]
@@ -55,8 +57,12 @@ pub enum LabelCommand {
         /// The number of labels to fetch per page
         #[clap(short = 'n', long)]
         per_page: Option<usize>,
+        /// The format we should display the results in.
+        #[clap(short, long, arg_enum, value_parser)]
+        format: OutputFormat,
     },
     /// Create a new label
+    #[clap(name = "create")]
     Create {
         /// The name of the label
         #[clap(short, long)]
@@ -69,17 +75,20 @@ pub enum LabelCommand {
         description: Option<String>,
     },
     /// Delete a label
+    #[clap(name = "delete")]
     Delete {
         /// The name of the label
         #[clap(short, long)]
         label: String,
     },
     /// Assign labels to a repo
+    #[clap(name = "assign")]
     Assign {
         /// A path to a file containing label definitions
         labels_file: String,
     },
     /// Edit an existing label
+    #[clap(name = "edit")]
     Edit {
         /// The name of the label
         #[clap(short, long)]
@@ -109,6 +118,32 @@ pub enum IssueCommand {
 #[derive(Debug, Args)]
 pub struct LabelArg {
     pub label: String,
+}
+
+#[derive(Debug, Clone, ValueEnum)]
+pub enum OutputFormat {
+    #[clap(name = "txt")]
+    Text,
+    #[clap(name = "json")]
+    Json,
+    #[clap(name = "yml")]
+    Yaml,
+}
+
+impl Default for OutputFormat {
+    fn default() -> Self {
+        OutputFormat::Text
+    }
+}
+
+impl Display for OutputFormat {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            OutputFormat::Text => write!(f, "txt"),
+            OutputFormat::Json => write!(f, "json"),
+            OutputFormat::Yaml => write!(f, "yml"),
+        }
+    }
 }
 
 #[cfg(test)]

--- a/cli/src/issue.rs
+++ b/cli/src/issue.rs
@@ -36,7 +36,8 @@ fn pretty_print(issue: Issue) {
     let mut table = pretty_table("Title", issue.title.as_str());
     table
         .add_row(["URL", issue.url.as_ref()])
-        .add_row(["State", issue.state.to_string().as_str()]);
+        .add_row(["State", issue.state.to_string().as_str()])
+        .add_row(["Labels"]);
     add_labels(&mut table, &issue.labels);
     println!("{table}");
     println!("{}", issue.body.unwrap_or_default());

--- a/cli/src/issue.rs
+++ b/cli/src/issue.rs
@@ -11,7 +11,7 @@ pub async fn run_issue_cmd(
     owner: &str,
     repo: &str,
     number: u64,
-    cmd: &IssueCommand,
+    cmd: IssueCommand,
 ) -> Result<(), ()> {
     let id = IssueId::new(owner, repo, number);
     match cmd {

--- a/cli/src/labels.rs
+++ b/cli/src/labels.rs
@@ -1,0 +1,142 @@
+use std::{fs::File, io::BufReader};
+
+use github_pilot_api::{models::Label, provider_traits::RepoProvider, wrappers::NewLabel};
+use log::{debug, error, info};
+
+use crate::{
+    cli_def::LabelCommand,
+    pretty_print::{add_labels, pretty_table},
+};
+
+pub async fn run_label_cmd(provider: &dyn RepoProvider, owner: &str, repo: &str, cmd: LabelCommand) -> Result<(), ()> {
+    match cmd {
+        LabelCommand::List { page, per_page } => fetch_labels(provider, owner, repo, page, per_page).await,
+        LabelCommand::Delete { label } => delete_label(provider, owner, repo, &label).await,
+        LabelCommand::Create {
+            name,
+            color,
+            description,
+        } => {
+            let label = NewLabel::new(name, color, description);
+            create_label(provider, owner, repo, label).await
+        },
+        LabelCommand::Assign { labels_file } => assign_labels(provider, owner, repo, &labels_file).await,
+        LabelCommand::Edit {
+            label,
+            name,
+            color,
+            description,
+        } => {
+            let new_name = name.unwrap_or(label.clone());
+            let new_label = NewLabel::new(new_name, color, description);
+            edit_label(provider, owner, repo, label, new_label).await
+        },
+    }
+}
+
+async fn assign_labels(provider: &dyn RepoProvider, owner: &str, repo: &str, labels: &String) -> Result<(), ()> {
+    let labels = load_labels(labels).map_err(|_| {
+        error!("🏷 Could not load labels");
+    })?;
+    debug!("🏷 Assigning {} labels to {owner}/{repo}", labels.len());
+    match provider.assign_labels(owner, repo, &labels[..]).await {
+        Ok(_) => {
+            info!("🏷 {} labels assigned to {owner}/{repo}", labels.len());
+            Ok(())
+        },
+        Err(e) => {
+            error!("🏷 Error assigning labels to {owner}/{repo}: {e}");
+            Err(())
+        },
+    }
+}
+
+fn load_labels(labels: &String) -> Result<Vec<NewLabel>, ()> {
+    let file = File::open(labels).map_err(|e| {
+        error!("🏷 Could not open file '{labels}': {e}");
+    })?;
+    let reader = BufReader::new(file);
+    let labels: Vec<NewLabel> = serde_yaml::from_reader(reader).map_err(|e| {
+        error!("🏷 Could not parse labels file '{labels}': {e}");
+    })?;
+    Ok(labels)
+}
+
+async fn edit_label(
+    provider: &dyn RepoProvider,
+    owner: &str,
+    repo: &str,
+    label: String,
+    new: NewLabel,
+) -> Result<(), ()> {
+    match provider.edit_label(owner, repo, label.as_str(), &new).await {
+        Ok(edited) => {
+            if edited {
+                info!("🏷 Label '{label}' edited");
+            } else {
+                info!("🏷 Label '{label}' not found");
+            }
+            Ok(())
+        },
+        Err(e) => {
+            error!("🏷 Error editing label '{label}': {e}");
+            Err(())
+        },
+    }
+}
+
+async fn delete_label(provider: &dyn RepoProvider, owner: &str, repo: &str, label: &String) -> Result<(), ()> {
+    match provider.delete_label(owner, repo, label).await {
+        Ok(true) => {
+            info!("🏷 Label {label} deleted");
+            Ok(())
+        },
+        Ok(false) => {
+            info!("🏷 Label {label} not found, so was not deleted");
+            Ok(())
+        },
+        Err(e) => {
+            error!("🏷 Error deleting label: {e}");
+            Err(())
+        },
+    }
+}
+
+async fn fetch_labels(
+    provider: &dyn RepoProvider,
+    owner: &str,
+    repo: &str,
+    page: Option<usize>,
+    per_page: Option<usize>,
+) -> Result<(), ()> {
+    match provider.fetch_labels(owner, repo, page, per_page).await {
+        Ok(labels) => {
+            pretty_print(&labels);
+            Ok(())
+        },
+        Err(e) => {
+            error!("🏷 Error fetching labels: {e}");
+            Err(())
+        },
+    }
+}
+
+async fn create_label(provider: &dyn RepoProvider, owner: &str, repo: &str, label: NewLabel) -> Result<(), ()> {
+    let name = label.name.clone();
+    match provider.assign_labels(owner, repo, &[label]).await {
+        Ok(()) => {
+            info!("🏷 Label {name} created");
+            Ok(())
+        },
+        Err(e) => {
+            error!("🏷 Error creating label '{name}': {e}");
+            Err(())
+        },
+    }
+}
+
+fn pretty_print(labels: &[Label]) {
+    let mut table = pretty_table("Label", "Description");
+    add_labels(&mut table, labels);
+    println!("{table}");
+}

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,5 +1,6 @@
 mod cli_def;
 mod issue;
+mod labels;
 mod pretty_print;
 mod pull_request;
 mod user;
@@ -9,7 +10,7 @@ use cli_def::{Cli, Commands};
 use github_pilot_api::GithubProvider;
 use log::*;
 
-use crate::{issue::run_issue_cmd, pull_request::run_pr_cmd, user::run_user_cmd};
+use crate::{issue::run_issue_cmd, labels::run_label_cmd, pull_request::run_pr_cmd, user::run_user_cmd};
 
 #[tokio::main]
 async fn main() -> Result<(), ()> {
@@ -18,10 +19,11 @@ async fn main() -> Result<(), ()> {
     let provider = setup_github_api(&cli);
     let owner = cli.owner.as_str();
     let repo = cli.repo.as_str();
-    match &cli.command {
-        Commands::User { profile } => run_user_cmd(&provider, profile).await,
-        Commands::PullRequest { number } => run_pr_cmd(&provider, owner, repo, *number).await,
-        Commands::Issue { number, sub_command } => run_issue_cmd(&provider, owner, repo, *number, sub_command).await,
+    match cli.command {
+        Commands::User { profile } => run_user_cmd(&provider, &profile).await,
+        Commands::PullRequest { number } => run_pr_cmd(&provider, owner, repo, number).await,
+        Commands::Issue { number, sub_command } => run_issue_cmd(&provider, owner, repo, number, sub_command).await,
+        Commands::Labels { sub_command } => run_label_cmd(&provider, owner, repo, sub_command).await,
     }
 }
 

--- a/cli/src/pretty_print.rs
+++ b/cli/src/pretty_print.rs
@@ -14,18 +14,19 @@ pub fn pretty_table(header_label: &str, header_value: &str) -> Table {
 }
 
 pub fn add_labels(table: &mut Table, labels: &[Label]) {
-    table.add_row(["Labels"]);
     labels.iter().for_each(|label| {
         let mut row = Row::new();
         let color = color_from_hex(label.color.as_str());
         let desc = label.description.as_deref().unwrap_or_default();
-        row.add_cell(cc(color, label.name.as_str())).add_cell(Cell::new(desc));
+        row.add_cell(cc(color, label.name.as_str()))
+            .add_cell(Cell::new(&label.color))
+            .add_cell(Cell::new(desc));
         table.add_row(row);
     })
 }
 
 pub fn cc(color: Color, val: &str) -> Cell {
-    Cell::new(val).fg(color)
+    Cell::new(val).fg(color).bg(Color::Black)
 }
 
 pub fn color_from_hex(hex_code: &str) -> Color {

--- a/cli/src/pull_request.rs
+++ b/cli/src/pull_request.rs
@@ -16,7 +16,8 @@ fn pretty_print(pr: PullRequest) {
     table
         .add_row(["URL", pr.url.as_ref()])
         .add_row(["State", pr.state.to_string().as_str()])
-        .add_row(["Merged", if matches!(pr.merged, Some(true)) { "Yes" } else { "No" }]);
+        .add_row(["Merged", if matches!(pr.merged, Some(true)) { "Yes" } else { "No" }])
+        .add_row(["Labels"]);
     add_labels(&mut table, &pr.labels);
     println!("{table}");
     println!("{}", pr.body.unwrap_or_else(|| "No body provided".into()));

--- a/github-api/src/api/client_proxy.rs
+++ b/github-api/src/api/client_proxy.rs
@@ -75,7 +75,13 @@ impl ClientProxy {
             .await
             .map_err(|e| GithubApiError::HttpClientError(e.to_string()))?;
         match response.status() {
-            StatusCode::OK => response
+            StatusCode::OK |
+            StatusCode::CREATED |
+            StatusCode::ACCEPTED |
+            StatusCode::PARTIAL_CONTENT |
+            StatusCode::RESET_CONTENT |
+            StatusCode::MULTI_STATUS |
+            StatusCode::ALREADY_REPORTED => response
                 .json()
                 .await
                 .map_err(|e| GithubApiError::DeserializationError(e.to_string())),

--- a/github-api/src/api/client_proxy.rs
+++ b/github-api/src/api/client_proxy.rs
@@ -65,6 +65,10 @@ impl ClientProxy {
         self.request(Method::PUT, url, true)
     }
 
+    pub fn patch<S: AsRef<str>>(&self, url: S) -> RequestBuilder {
+        self.request(Method::PATCH, url, true)
+    }
+
     pub async fn send<T: DeserializeOwned>(&self, request: RequestBuilder) -> Result<T, GithubApiError> {
         let response = request
             .send()

--- a/github-api/src/api/error.rs
+++ b/github-api/src/api/error.rs
@@ -20,4 +20,6 @@ pub enum GithubApiError {
     HttpResponse(StatusCode),
     #[error("Could not parse {0} as a valid timestamp")]
     InvalidTimestamp(String),
+    #[error("Multiple errors occurred: {0:?}")]
+    MultipleErrors(Vec<GithubApiError>),
 }

--- a/github-api/src/api/mod.rs
+++ b/github-api/src/api/mod.rs
@@ -4,6 +4,7 @@ mod error;
 mod issue;
 mod pull_request;
 mod query_trait;
+mod repo_request;
 
 pub use auth::AuthToken;
 pub use client_proxy::ClientProxy;
@@ -11,3 +12,4 @@ pub use error::GithubApiError;
 pub use issue::IssueRequest;
 pub use pull_request::PullRequestRequest;
 pub use query_trait::{GithubQuery, GithubQueryExec};
+pub use repo_request::RepoRequest;

--- a/github-api/src/api/repo_request.rs
+++ b/github-api/src/api/repo_request.rs
@@ -1,0 +1,62 @@
+use crate::{
+    api::{ClientProxy, GithubApiError},
+    models::{Label, Repository},
+    wrappers::NewLabel,
+};
+
+pub struct RepoRequest {
+    owner: String,
+    repo: String,
+}
+
+impl RepoRequest {
+    pub fn new<S: Into<String>, R: Into<String>>(owner: S, repo: R) -> Self {
+        Self {
+            owner: owner.into(),
+            repo: repo.into(),
+        }
+    }
+
+    pub fn repo(&self) -> &str {
+        self.repo.as_str()
+    }
+
+    pub fn owner(&self) -> &str {
+        self.owner.as_str()
+    }
+
+    pub async fn fetch(&self, proxy: &ClientProxy) -> Result<Repository, GithubApiError> {
+        let url = format!("/repo/{}/{}", self.owner, self.repo);
+        let req = proxy.get(&url, false);
+        proxy.send(req).await
+    }
+
+    pub async fn fetch_labels(
+        &self,
+        proxy: &ClientProxy,
+        page: usize,
+        per_page: usize,
+    ) -> Result<Vec<Label>, GithubApiError> {
+        let url = format!("/repos/{}/{}/labels", self.owner, self.repo);
+        let req = proxy.get(&url, false).query(&[("page", page), ("per_page", per_page)]);
+        proxy.send(req).await
+    }
+
+    pub async fn delete_label(&self, proxy: &ClientProxy, label: &str) -> Result<bool, GithubApiError> {
+        let url = format!("/repos/{}/{}/labels/{label}", self.owner, self.repo);
+        let req = proxy.delete(url);
+        proxy.send(req).await
+    }
+
+    pub async fn assign_labels(&self, proxy: &ClientProxy, labels: &[NewLabel]) -> Result<(), GithubApiError> {
+        let url = format!("/repos/{}/{}/labels", self.owner, self.repo);
+        let req = proxy.post(url).json(labels);
+        proxy.send(req).await
+    }
+
+    pub async fn edit_label(&self, proxy: &ClientProxy, label: &str, new: &NewLabel) -> Result<bool, GithubApiError> {
+        let url = format!("/repos/{}/{}/labels/{label}", self.owner, self.repo);
+        let req = proxy.patch(url).json(new);
+        proxy.send(req).await
+    }
+}

--- a/github-api/src/provider_traits/mod.rs
+++ b/github-api/src/provider_traits/mod.rs
@@ -1,7 +1,9 @@
 mod issue_provider;
 mod pull_request_provider;
+mod repo_provider;
 mod user_provider;
 
 pub use issue_provider::IssueProvider;
 pub use pull_request_provider::PullRequestProvider;
+pub use repo_provider::RepoProvider;
 pub use user_provider::UserProvider;

--- a/github-api/src/provider_traits/repo_provider.rs
+++ b/github-api/src/provider_traits/repo_provider.rs
@@ -1,0 +1,29 @@
+use async_trait::async_trait;
+
+use crate::{
+    error::GithubProviderError,
+    models::{Label, Repository},
+    wrappers::NewLabel,
+};
+
+#[async_trait]
+pub trait RepoProvider {
+    async fn fetch_repository(&self, owner: &str, repo: &str) -> Result<Repository, GithubProviderError>;
+    // Label functionality
+    async fn fetch_labels(
+        &self,
+        owner: &str,
+        repo: &str,
+        page: Option<usize>,
+        per_page: Option<usize>,
+    ) -> Result<Vec<Label>, GithubProviderError>;
+    async fn delete_label(&self, owner: &str, repo: &str, label: &str) -> Result<bool, GithubProviderError>;
+    async fn assign_labels(&self, owner: &str, repo: &str, labels: &[NewLabel]) -> Result<(), GithubProviderError>;
+    async fn edit_label(
+        &self,
+        owner: &str,
+        repo: &str,
+        label: &str,
+        new: &NewLabel,
+    ) -> Result<bool, GithubProviderError>;
+}

--- a/github-api/src/wrappers/mod.rs
+++ b/github-api/src/wrappers/mod.rs
@@ -1,6 +1,9 @@
 use crate::newtype;
 
 mod issue_id;
+mod new_label;
+
 pub use issue_id::IssueId;
+pub use new_label::NewLabel;
 
 newtype!(GithubHandle, String, str);

--- a/github-api/src/wrappers/new_label.rs
+++ b/github-api/src/wrappers/new_label.rs
@@ -1,0 +1,28 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct NewLabel {
+    pub name: String,
+    pub color: Option<String>,
+    pub description: Option<String>,
+}
+
+impl NewLabel {
+    pub fn new<S1: Into<String>>(name: S1, color: Option<String>, description: Option<String>) -> Self {
+        Self {
+            name: name.into(),
+            color,
+            description,
+        }
+    }
+}
+
+impl<S: AsRef<str>> From<S> for NewLabel {
+    fn from(s: S) -> Self {
+        Self {
+            name: s.as_ref().to_string(),
+            color: None,
+            description: None,
+        }
+    }
+}

--- a/presets/labels.yml
+++ b/presets/labels.yml
@@ -1,0 +1,27 @@
+# This is a set of opinionated labels that are derived from the Tari contribution guidelines.
+# https://github.com/tari-project/tari/blob/development/Contributing.md
+# You can apply these to your repo with the command
+# $ ghp-cli -o owner -r repo labels assign -f presets/labels.yml
+- name: C-bug
+  description: Something isn't working
+  color: d73a4a
+
+- name: CR-insufficient_context
+  description: 'The PR body does not provide enough information to fully describe the changes requested.'
+  color: FBE057
+
+- name: 'C-Documentation'
+  description: 'This PR or issue is related to documentation.'
+  color: 56a6ff
+
+- name: 'C-Duplicate'
+  description: This issue or pull request already exists
+  color: cfd3d7
+
+- name: good first issue
+  description: Good for newcomers
+  color: 7057ff
+
+- name: P-conflicts
+  description: The PR has merge conflicts that need to be resolved
+  color: D50030


### PR DESCRIPTION
Given a file like

```yml
# This is a set of opinionated labels that are derived from the Tari contribution guidelines.
# https://github.com/tari-project/tari/blob/development/Contributing.md
# You can apply these to your repo with the command
# $ ghp-cli -o owner -r repo labels assign -f presets/labels.yml
- name: C-bug
  description: Something isn't working
  color: d73a4a

- name: CR-insufficient_context
  description: 'The PR body does not provide enough information to fully describe the changes requested.'
  color: FBE057

- name: 'C-Documentation'
  description: 'This PR or issue is related to documentation.'
  color: 56a6ff

- name: 'C-Duplicate'
  description: This issue or pull request already exists
  color: cfd3d7

- name: good first issue
  description: Good for newcomers
  color: 7057ff

- name: P-conflicts
  description: The PR has merge conflicts that need to be resolved
  color: D50030
```

Simply run 
```
ghp-cli -o {owner} -r {repo} labels assign -f path/to/file.yml
```

and all your labels are added to your repo. 🚀 

## But where to get such a list?

If you have a repo with labels you like already...

```
ghp-cli -o tari-project -r gh-pilot labels list -f yml
```

```yml
- id: 4555292708
  node_id: LA_kwDOHxjpn88AAAABD4RAJA
  url: https://api.github.com/repos/tari-project/gh-pilot/labels/C-bug
  name: C-bug
  description: Something isn't working
  color: d73a4a
  default: false
- id: 4555371895
  node_id: LA_kwDOHxjpn88AAAABD4V1dw
  url: https://api.github.com/repos/tari-project/gh-pilot/labels/C-Documentation
  name: C-Documentation
  description: This PR or issue is related to documentation.
  color: 56a6ff
  default: false
- id: 4555371915
  node_id: LA_kwDOHxjpn88AAAABD4V1iw
  url: https://api.github.com/repos/tari-project/gh-pilot/labels/C-Duplicate
  name: C-Duplicate
  description: This issue or pull request already exists
  color: cfd3d7
  default: false
- id: 4538755387
  node_id: LA_kwDOHxjpn88AAAABDofpOw
  url: https://api.github.com/repos/tari-project/gh-pilot/labels/CR-insufficient_context
  name: CR-insufficient_context
  description: Please provide more detail in the PR description as to what this PR accomplishes
  color: FBCA04
  default: false
- id: 4398375674
  node_id: LA_kwDOHxjpn88AAAABBini-g
  url: https://api.github.com/repos/tari-project/gh-pilot/labels/good%20first%20issue
  name: good first issue
  description: Good for newcomers
  color: 7057ff
  default: true
- id: 4398375676
  node_id: LA_kwDOHxjpn88AAAABBini_A
  url: https://api.github.com/repos/tari-project/gh-pilot/labels/invalid
  name: invalid
  description: This doesn't seem right
  color: e4e669
  default: true
- id: 4555371944
  node_id: LA_kwDOHxjpn88AAAABD4V1qA
  url: https://api.github.com/repos/tari-project/gh-pilot/labels/P-conflicts
  name: P-conflicts
  description: The PR has merge conflicts that need to be resolved
  color: D50030
  default: false
- id: 4398375677
  node_id: LA_kwDOHxjpn88AAAABBini_Q
  url: https://api.github.com/repos/tari-project/gh-pilot/labels/question
  name: question
  description: Further information is requested
  color: d876e3
  default: true
- id: 4534499304
  node_id: LA_kwDOHxjpn88AAAABDkb36A
  url: https://api.github.com/repos/tari-project/gh-pilot/labels/T-bar
  name: T-bar
  description: null
  color: ededed
  default: false
- id: 4534426434
  node_id: LA_kwDOHxjpn88AAAABDkXbQg
  url: https://api.github.com/repos/tari-project/gh-pilot/labels/T-foo
  name: T-foo
  description: ''
  color: 7A2F2E
  default: false
```

