### PR TITLE
feat: add query to pull repo contributors

### DIFF
--- a/cli/src/cli_def.rs
+++ b/cli/src/cli_def.rs
@@ -44,6 +44,8 @@ pub enum Commands {
         #[clap(subcommand)]
         sub_command: LabelCommand,
     },
+    /// List contributors to the repo
+    Contributors,
 }
 
 #[derive(Debug, Subcommand)]

--- a/cli/src/contributors.rs
+++ b/cli/src/contributors.rs
@@ -1,0 +1,20 @@
+use github_pilot_api::{provider_traits::Contributors, GithubProvider};
+use log::warn;
+
+use crate::pretty_print::pretty_table;
+
+pub async fn run_contributor_cmd(provider: &GithubProvider, owner: &str, repo: &str) -> Result<(), ()> {
+    let contributors = provider.get_contributors(owner, repo).await.map_err(|e| {
+        warn!("⏩ Error fetching contributors: {}", e.to_string());
+    })?;
+    println!("👀 {} Contributors for {owner}/{repo}:", contributors.len());
+    let mut table = pretty_table("Name", "Contributions");
+    for contributor in contributors {
+        table.add_row([
+            contributor.login.as_str(),
+            contributor.contributions.to_string().as_str(),
+        ]);
+    }
+    println!("{table}");
+    Ok(())
+}

--- a/cli/src/labels.rs
+++ b/cli/src/labels.rs
@@ -30,7 +30,7 @@ pub async fn run_label_cmd(provider: &dyn RepoProvider, owner: &str, repo: &str,
             color,
             description,
         } => {
-            let new_name = name.unwrap_or(label.clone());
+            let new_name = name.unwrap_or_else(|| label.clone());
             let new_label = NewLabel::new(new_name, color, description);
             edit_label(provider, owner, repo, label, new_label).await
         },

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,4 +1,5 @@
 mod cli_def;
+mod contributors;
 mod issue;
 mod labels;
 mod pretty_print;
@@ -10,7 +11,13 @@ use cli_def::{Cli, Commands};
 use github_pilot_api::GithubProvider;
 use log::*;
 
-use crate::{issue::run_issue_cmd, labels::run_label_cmd, pull_request::run_pr_cmd, user::run_user_cmd};
+use crate::{
+    contributors::run_contributor_cmd,
+    issue::run_issue_cmd,
+    labels::run_label_cmd,
+    pull_request::run_pr_cmd,
+    user::run_user_cmd,
+};
 
 #[tokio::main]
 async fn main() -> Result<(), ()> {
@@ -24,6 +31,7 @@ async fn main() -> Result<(), ()> {
         Commands::PullRequest { number } => run_pr_cmd(&provider, owner, repo, number).await,
         Commands::Issue { number, sub_command } => run_issue_cmd(&provider, owner, repo, number, sub_command).await,
         Commands::Labels { sub_command } => run_label_cmd(&provider, owner, repo, sub_command).await,
+        Commands::Contributors => run_contributor_cmd(&provider, owner, repo).await,
     }
 }
 

--- a/cli/src/pretty_print.rs
+++ b/cli/src/pretty_print.rs
@@ -10,6 +10,7 @@ pub fn pretty_table(header_label: &str, header_value: &str) -> Table {
     name_row
         .add_cell(cc(Color::Green, header_label))
         .add_cell(cc(Color::Green, header_value));
+    table.add_row(name_row);
     table
 }
 

--- a/github-api/src/api/repo_request.rs
+++ b/github-api/src/api/repo_request.rs
@@ -92,7 +92,8 @@ impl RepoRequest {
 
     pub async fn fetch_contributors(&self, proxy: &ClientProxy) -> Result<Vec<Contributor>, GithubApiError> {
         let url = format!("/repos/{}/{}/contributors", self.owner, self.repo);
-        let req = proxy.get(&url, false);
+        let req = proxy.get(&url, false).query(&[("page", 1), ("per_page", 100)]);
+        // TODO - use the "link" response header to get all pages.
         let contributors: Vec<Contributor> = proxy.send(req).await?;
         let contributors = contributors
             .into_iter()

--- a/github-api/src/github_provider.rs
+++ b/github-api/src/github_provider.rs
@@ -6,8 +6,8 @@ use log::*;
 use crate::{
     api::{AuthToken, ClientProxy, IssueRequest, PullRequestRequest, RepoRequest},
     error::GithubProviderError,
-    models::{Issue, Label, PullRequest, Repository, SimpleUser},
-    provider_traits::{IssueProvider, PullRequestProvider, RepoProvider, UserProvider},
+    models::{Contributor, Issue, Label, PullRequest, Repository, SimpleUser},
+    provider_traits::{Contributors, IssueProvider, PullRequestProvider, RepoProvider, UserProvider},
     wrappers::{GithubHandle, IssueId, NewLabel},
 };
 
@@ -163,6 +163,15 @@ impl RepoProvider for GithubProvider {
     ) -> Result<bool, GithubProviderError> {
         let repo = RepoRequest::new(owner, repo);
         let result = repo.edit_label(&self.client, label, new).await?;
+        Ok(result)
+    }
+}
+
+#[async_trait]
+impl Contributors for GithubProvider {
+    async fn get_contributors(&self, owner: &str, repo: &str) -> Result<Vec<Contributor>, GithubProviderError> {
+        let repo = RepoRequest::new(owner, repo);
+        let result = repo.fetch_contributors(&self.client).await?;
         Ok(result)
     }
 }

--- a/github-api/src/models/user.rs
+++ b/github-api/src/models/user.rs
@@ -25,7 +25,7 @@ pub struct SimpleUser {
     pub starred_url: Option<String>,
     pub subscriptions_url: Option<Url>,
     #[serde(rename = "type")]
-    pub user_type: Option<String>,
+    pub user_type: Option<UserType>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialOrd, Ord, PartialEq, Eq, Hash)]
@@ -43,4 +43,28 @@ impl ToString for UserType {
             UserType::Organization => "Organization".to_string(),
         }
     }
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct Contributor {
+    pub login: String,
+    pub id: i64,
+    pub node_id: String,
+    pub site_admin: bool,
+    pub contributions: i64,
+    pub avatar_url: Option<String>,
+    pub gravatar_id: Option<String>,
+    pub url: Option<String>,
+    pub html_url: Option<String>,
+    pub followers_url: Option<String>,
+    pub following_url: Option<String>,
+    pub gists_url: Option<String>,
+    pub starred_url: Option<String>,
+    pub subscriptions_url: Option<String>,
+    pub organizations_url: Option<String>,
+    pub repos_url: Option<String>,
+    pub events_url: Option<String>,
+    pub received_events_url: Option<String>,
+    #[serde(rename = "type")]
+    pub user_type: Option<UserType>,
 }

--- a/github-api/src/provider_traits/mod.rs
+++ b/github-api/src/provider_traits/mod.rs
@@ -5,5 +5,5 @@ mod user_provider;
 
 pub use issue_provider::IssueProvider;
 pub use pull_request_provider::PullRequestProvider;
-pub use repo_provider::RepoProvider;
+pub use repo_provider::{Contributors, RepoProvider};
 pub use user_provider::UserProvider;

--- a/github-api/src/provider_traits/repo_provider.rs
+++ b/github-api/src/provider_traits/repo_provider.rs
@@ -2,7 +2,7 @@ use async_trait::async_trait;
 
 use crate::{
     error::GithubProviderError,
-    models::{Label, Repository},
+    models::{Contributor, Label, Repository},
     wrappers::NewLabel,
 };
 
@@ -26,4 +26,9 @@ pub trait RepoProvider {
         label: &str,
         new: &NewLabel,
     ) -> Result<bool, GithubProviderError>;
+}
+
+#[async_trait]
+pub trait Contributors {
+    async fn get_contributors(&self, owner: &str, repo: &str) -> Result<Vec<Contributor>, GithubProviderError>;
 }

--- a/github-api/src/webhooks/mod.rs
+++ b/github-api/src/webhooks/mod.rs
@@ -85,7 +85,7 @@ impl GithubEvent {
             Self::Issues(iss) => format!("Issue {}: {}", iss.action.to_string(), iss.issue.title),
             Self::Label(lab) => format!("Label {}: {}", lab.action.to_string(), lab.label.name),
             Self::Ping(p) => format!("Ping: {}", p.zen),
-            Self::PullRequest(pr) => format!("Pull request {}: {}", pr.action.to_string(), pr.pull_request.title),
+            Self::PullRequest(pr) => format!("Pull request {}: {}", pr.action, pr.pull_request.title),
             Self::PullRequestReview(r) => {
                 format!("Pull request review {}: {}", r.action.to_string(), r.pull_request.title)
             },
@@ -114,7 +114,7 @@ impl GithubEvent {
 #[cfg(test)]
 mod test {
     use crate::{
-        models::{AuthorAssociation, State},
+        models::{AuthorAssociation, State, UserType},
         webhooks::{
             GithubEvent,
             IssueCommentAction,
@@ -230,7 +230,7 @@ mod test {
                     pr.info.organization.clone().unwrap().url,
                     "https://api.github.com/orgs/tari-project"
                 );
-                assert_eq!(pr.info.sender.user_type, Some("User".to_string()));
+                assert_eq!(pr.info.sender.user_type, Some(UserType::User));
             },
             _ => panic!("Not a pull_request event"),
         }

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -5,11 +5,7 @@ async fn main() {
     env_logger::init();
     let config = ServerConfig::new("127.0.0.1", 8330);
     match run_server(config).await {
-        Ok(_) => {
-            println!("Bye!");
-        },
-        Err(e) => {
-            eprintln!("{}", e.to_string())
-        },
+        Ok(_) => println!("Bye!"),
+        Err(e) => eprintln!("{e}"),
     }
 }

--- a/server/src/pub_sub/actor.rs
+++ b/server/src/pub_sub/actor.rs
@@ -73,9 +73,9 @@ impl PubSubActor {
         let name = format!("ClosureAction-{}", timestamp());
         let msg = ClosureActionMessage::new(name, ev_name, ev, params);
         let executor = ClosureActionExecutor::from_registry();
-        executor.try_send(msg).map_err(|e| {
-            PubSubError::DispatchError(format!("Could not dispatch Closure Action message. {}", e.to_string()))
-        })
+        executor
+            .try_send(msg)
+            .map_err(|e| PubSubError::DispatchError(format!("Could not dispatch Closure Action message. {}", e)))
     }
 
     fn dispatch_github_action(
@@ -87,9 +87,9 @@ impl PubSubActor {
         let name = format!("GithubAction-{}", timestamp());
         let msg = GithubActionMessage::new(name, ev_name, ev, params);
         let executor = GithubActionExecutor::from_registry();
-        executor.try_send(msg).map_err(|e| {
-            PubSubError::DispatchError(format!("Could not dispatch Github Action message. {}", e.to_string()))
-        })
+        executor
+            .try_send(msg)
+            .map_err(|e| PubSubError::DispatchError(format!("Could not dispatch Github Action message. {}", e)))
     }
 }
 

--- a/server/src/routes.rs
+++ b/server/src/routes.rs
@@ -59,7 +59,7 @@ pub async fn github_webhook(
     }
     let event_name = headers
         .get("x-github-event")
-        .ok_or(ServerError::InvalidEventHeader("x-github-event is missing".into()))?
+        .ok_or_else(|| ServerError::InvalidEventHeader("x-github-event is missing".into()))?
         .to_str()
         .map_err(|_| ServerError::InvalidEventHeader("x-github-event is not a valid string".into()))?;
     trace!("💻 Extracted event name: {}", event_name);

--- a/server/src/utilities.rs
+++ b/server/src/utilities.rs
@@ -12,7 +12,7 @@ pub fn timestamp() -> String {
     SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .map(|d| d.as_secs().to_string())
-        .unwrap_or("0000000".to_string())
+        .unwrap_or_else(|_| "0000000".to_string())
 }
 
 pub fn check_valid_signature(secret: &str, signature: &str, payload: &str) -> Result<(), ServerError> {
@@ -40,9 +40,7 @@ pub fn get_secret() -> Result<String, ServerError> {
 pub fn extract_signature(headers: &HeaderMap) -> Result<&str, ServerError> {
     headers
         .get("x-hub-signature-256")
-        .ok_or(ServerError::InvalidSignatureHeader(
-            "x-hub-signature-256 is missing".into(),
-        ))?
+        .ok_or_else(|| ServerError::InvalidSignatureHeader("x-hub-signature-256 is missing".into()))?
         .to_str()
         .map_err(|_| ServerError::InvalidSignatureHeader("x-hub-signature-256 is not a valid string".into()))
 }


### PR DESCRIPTION
Adds a feature to pull the list of contributors to a repo, filtering out
bots and orgs.

the CLI command
chp_cli -o {owner} -r {repo} contributors
will print a list of contributors to the terminal

Adds a trait and githubProvider impl to fetch a repo's list of
contributors.

The /contributors endpoint only returns the first 100 contributors, so
beyond this, you need to use another method of tracking project
contributors.

The repo request method filters out non USER accounts and empty logins
before returning the contributor list

