### PR TITLE
feat: add pr-merge to sdk and cli

### DIFF
--- a/cli/src/cli_def.rs
+++ b/cli/src/cli_def.rs
@@ -1,6 +1,7 @@
 use std::fmt::Display;
 
 use clap::{Args, Parser, Subcommand, ValueEnum};
+use github_pilot_api::models_plus::{MergeMethod, MergeParameters};
 
 #[derive(Parser, Debug)]
 #[clap(author, version, about, long_about = None)]
@@ -161,6 +162,31 @@ pub enum PullRequestCommand {
     RemoveLabel(LabelArg),
     /// Retrieve the comments and review comment threads for a PR
     Comments,
+    /// Try to merge the PR
+    Merge(MergeArgs),
+}
+
+#[derive(Debug, Args)]
+pub struct MergeArgs {
+    /// Override the title for the commit message
+    pub commit_title: Option<String>,
+    /// Override the commit message for the merge
+    pub commit_message: Option<String>,
+    /// Require the HEAD to have this SHA value before allowing a merge
+    pub sha: Option<String>,
+    /// Specify the merge method. Can be one of: merge, rebase, or squash. Default is merge.
+    pub merge_method: Option<MergeMethod>,
+}
+
+impl From<MergeArgs> for MergeParameters {
+    fn from(a: MergeArgs) -> Self {
+        MergeParameters {
+            commit_title: a.commit_title,
+            commit_message: a.commit_message,
+            sha: a.sha,
+            merge_method: a.merge_method.unwrap_or_default(),
+        }
+    }
 }
 
 #[cfg(test)]

--- a/github-api/src/api/error.rs
+++ b/github-api/src/api/error.rs
@@ -28,6 +28,8 @@ pub enum GithubApiError {
     ReqwestError(String),
     #[error("The GraphQL query returned errors: {0}")]
     GraphQLError(String),
+    #[error("The PR could not be merged: {0}")]
+    MergeError(String),
 }
 
 #[derive(Clone)]

--- a/github-api/src/github_provider.rs
+++ b/github-api/src/github_provider.rs
@@ -8,6 +8,7 @@ use crate::{
     error::GithubProviderError,
     graphql::PullRequestComments,
     models::{Contributor, Issue, Label, PullRequest, Repository, SimpleUser},
+    models_plus::{MergeParameters, MergeResult},
     provider_traits::{
         Contributors,
         IssueProvider,
@@ -81,6 +82,16 @@ impl PullRequestProvider for GithubProvider {
     ) -> Result<PullRequest, GithubProviderError> {
         let pr = PullRequestRequest::new(owner, repo, number);
         let result = pr.fetch(&self.client).await?;
+        Ok(result)
+    }
+
+    async fn merge_pull_request(
+        &self,
+        id: &IssueId,
+        params: MergeParameters,
+    ) -> Result<MergeResult, GithubProviderError> {
+        let pr = PullRequestRequest::from(id);
+        let result = pr.merge(&self.client, params).await?;
         Ok(result)
     }
 }

--- a/github-api/src/models_plus/mod.rs
+++ b/github-api/src/models_plus/mod.rs
@@ -2,3 +2,5 @@
 //! The code is kept separate to avoid messing with the code generation tools.
 
 mod pull_request;
+
+pub use pull_request::*;

--- a/github-api/src/models_plus/pull_request.rs
+++ b/github-api/src/models_plus/pull_request.rs
@@ -1,4 +1,50 @@
+use std::str::FromStr;
+
+use serde::{Deserialize, Serialize};
+
 use crate::models::PullRequest;
+
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+pub struct MergeParameters {
+    pub commit_title: Option<String>,
+    pub commit_message: Option<String>,
+    pub sha: Option<String>,
+    pub merge_method: MergeMethod,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MergeMethod {
+    Merge,
+    Rebase,
+    Squash,
+}
+
+impl Default for MergeMethod {
+    fn default() -> Self {
+        MergeMethod::Merge
+    }
+}
+
+impl FromStr for MergeMethod {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "merge" => Ok(MergeMethod::Merge),
+            "rebase" => Ok(MergeMethod::Rebase),
+            "squash" => Ok(MergeMethod::Squash),
+            _ => Err(format!("Invalid merge method: {}", s)),
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct MergeResult {
+    pub sha: String,
+    pub merged: bool,
+    pub message: String,
+}
 
 impl PullRequest {
     pub fn has_merge_conflicts(&self) -> bool {

--- a/github-api/src/provider_traits/pull_request_provider.rs
+++ b/github-api/src/provider_traits/pull_request_provider.rs
@@ -1,6 +1,12 @@
 use async_trait::async_trait;
 
-use crate::{error::GithubProviderError, graphql::PullRequestComments, models::PullRequest, wrappers::IssueId};
+use crate::{
+    error::GithubProviderError,
+    graphql::PullRequestComments,
+    models::PullRequest,
+    models_plus::{MergeParameters, MergeResult},
+    wrappers::IssueId,
+};
 
 #[async_trait]
 pub trait PullRequestProvider {
@@ -10,6 +16,12 @@ pub trait PullRequestProvider {
         repo: &str,
         number: u64,
     ) -> Result<PullRequest, GithubProviderError>;
+
+    async fn merge_pull_request(
+        &self,
+        id: &IssueId,
+        params: MergeParameters,
+    ) -> Result<MergeResult, GithubProviderError>;
 }
 
 #[async_trait]


### PR DESCRIPTION
This PR adds the ability to merge a PR from the gh-pilot cli. This obv requires support form the API interface as well.