### PR TITLE
feat: graphql query for review counts

### DIFF
--- a/cli/src/cli_def.rs
+++ b/cli/src/cli_def.rs
@@ -164,6 +164,8 @@ pub enum PullRequestCommand {
     Comments,
     /// Try to merge the PR
     Merge(MergeArgs),
+    /// Fetch review statistics
+    Reviews,
 }
 
 #[derive(Debug, Args)]

--- a/github-api/src/github_provider.rs
+++ b/github-api/src/github_provider.rs
@@ -6,7 +6,7 @@ use log::*;
 use crate::{
     api::{AuthToken, ClientProxy, IssueRequest, PullRequestRequest, RepoRequest},
     error::GithubProviderError,
-    graphql::PullRequestComments,
+    graphql::{review_counts::ReviewCounts, PullRequestComments},
     models::{Contributor, Issue, Label, PullRequest, Repository, SimpleUser},
     models_plus::{MergeParameters, MergeResult},
     provider_traits::{
@@ -14,6 +14,7 @@ use crate::{
         IssueProvider,
         PullRequestCommentsProvider,
         PullRequestProvider,
+        PullRequestReviewSummary,
         RepoProvider,
         UserProvider,
     },
@@ -206,6 +207,16 @@ impl PullRequestCommentsProvider for GithubProvider {
         );
         let pr = PullRequestRequest::new(&pr_id.owner, &pr_id.repo, pr_id.number);
         let result = pr.fetch_comments(&self.client).await?;
+        Ok(result)
+    }
+}
+
+#[async_trait]
+impl PullRequestReviewSummary for GithubProvider {
+    async fn fetch_review_summary(&self, pr_id: &IssueId) -> Result<ReviewCounts, GithubProviderError> {
+        trace!("👀 Fetching pull request reviews for PR");
+        let pr = PullRequestRequest::new(&pr_id.owner, &pr_id.repo, pr_id.number);
+        let result = pr.fetch_review_counts(&self.client).await?;
         Ok(result)
     }
 }

--- a/github-api/src/graphql/data/pr_review_counts.graphql
+++ b/github-api/src/graphql/data/pr_review_counts.graphql
@@ -1,0 +1,24 @@
+query PullRequestReviewCountsQL($owner: String!, $repo: String!, $pr_number:Int!) {
+    repository(owner:$owner, name:$repo) {
+        owner {
+            __typename
+            login
+        }
+        name
+        pullRequest(number: $pr_number) {
+            title
+            number
+            reviews(states: [APPROVED, CHANGES_REQUESTED], first:100) {
+                totalCount
+                nodes {
+                    author {
+                        __typename
+                        login
+                    }
+                    createdAt
+                    state
+                }
+            }
+        }
+    }
+}

--- a/github-api/src/graphql/mod.rs
+++ b/github-api/src/graphql/mod.rs
@@ -1,3 +1,4 @@
 pub mod pr_comments;
+pub mod review_counts;
 
 pub use pr_comments::{Comment, CommentThread, PullRequestComments};

--- a/github-api/src/graphql/review_counts.rs
+++ b/github-api/src/graphql/review_counts.rs
@@ -1,0 +1,88 @@
+use graphql_client::GraphQLQuery;
+
+use crate::{models::DateTime, wrappers::IssueId};
+
+#[derive(GraphQLQuery)]
+#[graphql(
+    schema_path = "src/graphql/data/schema.graphql",
+    query_path = "src/graphql/data/pr_review_counts.graphql",
+    deprecated = "warn",
+    response_derives = "Debug, Clone"
+)]
+pub struct PullRequestReviewCountsQL;
+
+pub struct ReviewSummary {
+    pub author: String,
+    pub created_at: DateTime,
+    state: pull_request_review_counts_ql::PullRequestReviewState,
+}
+
+pub struct ReviewCounts {
+    total_count: usize,
+    id: IssueId,
+    title: String,
+    reviews: Vec<ReviewSummary>,
+}
+
+impl From<pull_request_review_counts_ql::ResponseData> for ReviewCounts {
+    fn from(ql: pull_request_review_counts_ql::ResponseData) -> Self {
+        use pull_request_review_counts_ql::{
+            PullRequestReviewCountsQlRepository as Repo,
+            PullRequestReviewCountsQlRepositoryPullRequest as PR,
+            PullRequestReviewCountsQlRepositoryPullRequestReviews as Reviews,
+        };
+
+        let (owner, name, pr) = match ql.repository {
+            Some(Repo {
+                pull_request: Some(pr),
+                owner,
+                name,
+            }) => (owner.login, name, pr),
+            _ => {
+                let pr = PR {
+                    number: 0,
+                    title: String::new(),
+                    reviews: None,
+                };
+                (Default::default(), Default::default(), pr)
+            },
+        };
+        let title = pr.title.clone();
+        let id = IssueId::new(owner, name, pr.number as u64);
+        let (total_count, nodes) = match pr.reviews {
+            Some(Reviews {
+                total_count,
+                nodes: Some(nodes),
+            }) => (total_count as usize, nodes),
+            Some(Reviews {
+                total_count,
+                nodes: None,
+            }) => (total_count as usize, vec![]),
+            None => (0, vec![]),
+        };
+        let reviews = nodes
+            .into_iter()
+            .flatten()
+            .map(|review| ReviewSummary {
+                author: review.author.map(|a| a.login).unwrap_or_default(),
+                created_at: review.created_at,
+                state: review.state,
+            })
+            .collect::<Vec<ReviewSummary>>();
+
+        if total_count != reviews.len() {
+            log::warn!(
+                "Review count mismatch: Expected {total_count}, Received {}. This is a bug requiring pagination to be \
+                 added to the API query",
+                reviews.len()
+            );
+        }
+
+        ReviewCounts {
+            total_count,
+            id,
+            title,
+            reviews,
+        }
+    }
+}

--- a/github-api/src/graphql/review_counts.rs
+++ b/github-api/src/graphql/review_counts.rs
@@ -7,7 +7,7 @@ use crate::{models::DateTime, wrappers::IssueId};
     schema_path = "src/graphql/data/schema.graphql",
     query_path = "src/graphql/data/pr_review_counts.graphql",
     deprecated = "warn",
-    response_derives = "Debug, Clone"
+    response_derives = "Debug, Clone, PartialEq, Eq"
 )]
 pub struct PullRequestReviewCountsQL;
 
@@ -22,6 +22,34 @@ pub struct ReviewCounts {
     id: IssueId,
     title: String,
     reviews: Vec<ReviewSummary>,
+}
+
+impl ReviewCounts {
+    pub fn total(&self) -> usize {
+        self.total_count
+    }
+
+    pub fn id(&self) -> &IssueId {
+        &self.id
+    }
+
+    pub fn title(&self) -> &str {
+        &self.title
+    }
+
+    pub fn approvals(&self) -> usize {
+        use pull_request_review_counts_ql::PullRequestReviewState::APPROVED;
+        self.reviews.iter().filter(|&r| r.state == APPROVED).count()
+    }
+
+    pub fn changes_requested(&self) -> bool {
+        use pull_request_review_counts_ql::PullRequestReviewState::CHANGES_REQUESTED;
+        self.reviews.iter().any(|r| r.state == CHANGES_REQUESTED)
+    }
+
+    pub fn reviewers(&self) -> Vec<String> {
+        self.reviews.iter().map(|r| r.author.clone()).collect()
+    }
 }
 
 impl From<pull_request_review_counts_ql::ResponseData> for ReviewCounts {

--- a/github-api/src/provider_traits/mod.rs
+++ b/github-api/src/provider_traits/mod.rs
@@ -4,6 +4,6 @@ mod repo_provider;
 mod user_provider;
 
 pub use issue_provider::IssueProvider;
-pub use pull_request_provider::{PullRequestCommentsProvider, PullRequestProvider};
+pub use pull_request_provider::{PullRequestCommentsProvider, PullRequestProvider, PullRequestReviewSummary};
 pub use repo_provider::{Contributors, RepoProvider};
 pub use user_provider::UserProvider;

--- a/github-api/src/provider_traits/pull_request_provider.rs
+++ b/github-api/src/provider_traits/pull_request_provider.rs
@@ -2,7 +2,7 @@ use async_trait::async_trait;
 
 use crate::{
     error::GithubProviderError,
-    graphql::PullRequestComments,
+    graphql::{review_counts::ReviewCounts, PullRequestComments},
     models::PullRequest,
     models_plus::{MergeParameters, MergeResult},
     wrappers::IssueId,
@@ -27,4 +27,9 @@ pub trait PullRequestProvider {
 #[async_trait]
 pub trait PullRequestCommentsProvider {
     async fn fetch_pull_request_comments(&self, pr_id: &IssueId) -> Result<PullRequestComments, GithubProviderError>;
+}
+
+#[async_trait]
+pub trait PullRequestReviewSummary {
+    async fn fetch_review_summary(&self, pr_id: &IssueId) -> Result<ReviewCounts, GithubProviderError>;
 }


### PR DESCRIPTION
You can now get a summary of PR reviews with the reviews subcommand.

### Example

```
$ ghp-cli -o "tari-project" -r "tari" pull-request -n 4234 reviews

┌──────────────────────────────────────────────────────┐
│ PR Reviews          feat: add sender to instructions │
│ Reviewers           sdbondi brianp SWvheerden        │
│ Approvals           3                                │
│ Changes requested   false                            │
└──────────────────────────────────────────────────────┘
```