### PR TITLE
feat: add cli command to fetch last check run

### DIFF
--- a/cli/src/cli_def.rs
+++ b/cli/src/cli_def.rs
@@ -166,6 +166,8 @@ pub enum PullRequestCommand {
     Merge(MergeArgs),
     /// Fetch review statistics
     Reviews,
+    /// Fetch last check run status (The result of the checks that are configured to run after each PR change).
+    Check,
 }
 
 #[derive(Debug, Args)]

--- a/cli/src/contributors.rs
+++ b/cli/src/contributors.rs
@@ -8,7 +8,7 @@ pub async fn run_contributor_cmd(provider: &GithubProvider, owner: &str, repo: &
         warn!("⏩ Error fetching contributors: {}", e.to_string());
     })?;
     println!("👀 {} Contributors for {owner}/{repo}:", contributors.len());
-    let mut table = pretty_table("Name", "Contributions");
+    let mut table = pretty_table(&["Name", "Contributions"]);
     for contributor in contributors {
         table.add_row([
             contributor.login.as_str(),

--- a/cli/src/issue.rs
+++ b/cli/src/issue.rs
@@ -33,7 +33,7 @@ pub async fn run_issue_cmd(
 }
 
 fn pretty_print(issue: Issue) {
-    let mut table = pretty_table("Title", issue.title.as_str());
+    let mut table = pretty_table(&["Title", issue.title.as_str()]);
     table
         .add_row(["URL", issue.url.as_ref()])
         .add_row(["State", issue.state.to_string().as_str()])

--- a/cli/src/pretty_print.rs
+++ b/cli/src/pretty_print.rs
@@ -1,15 +1,15 @@
 use comfy_table::{presets::UTF8_BORDERS_ONLY, Cell, Color, ContentArrangement, Row, Table};
 use github_pilot_api::models::Label;
 
-pub fn pretty_table(header_label: &str, header_value: &str) -> Table {
+pub fn pretty_table(headings: &[&str]) -> Table {
     let mut table = Table::new();
     table
         .load_preset(UTF8_BORDERS_ONLY)
         .set_content_arrangement(ContentArrangement::Dynamic);
     let mut name_row = Row::new();
-    name_row
-        .add_cell(cc(Color::Green, header_label))
-        .add_cell(cc(Color::Green, header_value));
+    for heading in headings {
+        name_row.add_cell(cc(Color::Green, heading));
+    }
     table.add_row(name_row);
     table
 }

--- a/github-api/src/github_provider.rs
+++ b/github-api/src/github_provider.rs
@@ -6,10 +6,11 @@ use log::*;
 use crate::{
     api::{AuthToken, ClientProxy, IssueRequest, PullRequestRequest, RepoRequest},
     error::GithubProviderError,
-    graphql::{review_counts::ReviewCounts, PullRequestComments},
+    graphql::{review_counts::ReviewCounts, CheckRunStatus, PullRequestComments},
     models::{Contributor, Issue, Label, PullRequest, Repository, SimpleUser},
     models_plus::{MergeParameters, MergeResult},
     provider_traits::{
+        CheckRunStatusProvider,
         Contributors,
         IssueProvider,
         PullRequestCommentsProvider,
@@ -217,6 +218,16 @@ impl PullRequestReviewSummary for GithubProvider {
         trace!("👀 Fetching pull request reviews for PR");
         let pr = PullRequestRequest::new(&pr_id.owner, &pr_id.repo, pr_id.number);
         let result = pr.fetch_review_counts(&self.client).await?;
+        Ok(result)
+    }
+}
+
+#[async_trait]
+impl CheckRunStatusProvider for GithubProvider {
+    async fn fetch_check_run(&self, pr_id: &IssueId) -> Result<CheckRunStatus, GithubProviderError> {
+        trace!("✅ Fetching check run status for PR");
+        let pr = PullRequestRequest::new(&pr_id.owner, &pr_id.repo, pr_id.number);
+        let result = pr.fetch_last_check_run(&self.client).await?;
         Ok(result)
     }
 }

--- a/github-api/src/graphql/data/check_run_status.graphql
+++ b/github-api/src/graphql/data/check_run_status.graphql
@@ -1,0 +1,35 @@
+query CheckRunStatusQL($owner: String!, $repo: String!, $pr_number: Int!) {
+    repository(owner: $owner, name:$repo) {
+        pullRequest(number:$pr_number) {
+            commits(last: 1) {
+                nodes {
+                    commit {
+                        url
+                        committedDate
+                        statusCheckRollup {
+                            state
+                        }
+                        checkSuites(last: 10) {
+                            totalCount
+                            nodes {
+                                app {
+                                    name
+                                }
+                                checkRuns(last: 10) {
+                                    totalCount
+                                    nodes {
+                                        completedAt
+                                        conclusion
+                                        isRequired(pullRequestNumber: $pr_number)
+                                        name
+                                        status
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/github-api/src/graphql/data/sample_check_run.json
+++ b/github-api/src/graphql/data/sample_check_run.json
@@ -1,0 +1,104 @@
+{
+    "repository": {
+      "pullRequest": {
+        "commits": {
+          "nodes": [
+            {
+              "commit": {
+                "url": "https://github.com/tari-project/gh-pilot/commit/c13501c51f6a3f5183f5921aa89d68110a29f0f4",
+                "committedDate": "2022-09-20T15:30:05Z",
+                "statusCheckRollup": {
+                  "state": "SUCCESS"
+                },
+                "checkSuites": {
+                  "totalCount": 4,
+                  "nodes": [
+                    {
+                      "app": {
+                        "name": "GitHub Actions"
+                      },
+                      "checkRuns": {
+                        "totalCount": 1,
+                        "nodes": [
+                          {
+                            "completedAt": "2022-09-20T15:35:54Z",
+                            "conclusion": "SUCCESS",
+                            "isRequired": false,
+                            "name": "clippy_check",
+                            "status": "COMPLETED",
+                            "summary": null
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "app": {
+                        "name": "GitHub Actions"
+                      },
+                      "checkRuns": {
+                        "totalCount": 1,
+                        "nodes": [
+                          {
+                            "completedAt": "2022-09-20T15:32:28Z",
+                            "conclusion": "SUCCESS",
+                            "isRequired": false,
+                            "name": "check-title",
+                            "status": "COMPLETED",
+                            "summary": null
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "app": {
+                        "name": "GitHub Actions"
+                      },
+                      "checkRuns": {
+                        "totalCount": 2,
+                        "nodes": [
+                          {
+                            "completedAt": "2022-09-20T15:42:12Z",
+                            "conclusion": "SUCCESS",
+                            "isRequired": false,
+                            "name": "cargo test (stable)",
+                            "status": "COMPLETED",
+                            "summary": null
+                          },
+                          {
+                            "completedAt": "2022-09-20T15:40:49Z",
+                            "conclusion": "SUCCESS",
+                            "isRequired": false,
+                            "name": "cargo test (nightly-2022-09-13)",
+                            "status": "COMPLETED",
+                            "summary": null
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "app": {
+                        "name": "GitHub Actions"
+                      },
+                      "checkRuns": {
+                        "totalCount": 1,
+                        "nodes": [
+                          {
+                            "completedAt": "2022-09-20T15:36:07Z",
+                            "conclusion": "SUCCESS",
+                            "isRequired": false,
+                            "name": "check-title",
+                            "status": "COMPLETED",
+                            "summary": null
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      }
+    }
+}

--- a/github-api/src/graphql/mod.rs
+++ b/github-api/src/graphql/mod.rs
@@ -1,4 +1,6 @@
 pub mod pr_comments;
 pub mod review_counts;
+pub mod run_status;
 
 pub use pr_comments::{Comment, CommentThread, PullRequestComments};
+pub use run_status::{RunStatus, RunStatuses};

--- a/github-api/src/graphql/mod.rs
+++ b/github-api/src/graphql/mod.rs
@@ -3,4 +3,4 @@ pub mod review_counts;
 pub mod run_status;
 
 pub use pr_comments::{Comment, CommentThread, PullRequestComments};
-pub use run_status::{RunStatus, RunStatuses};
+pub use run_status::{CheckRunStatus, RunStatus};

--- a/github-api/src/graphql/run_status.rs
+++ b/github-api/src/graphql/run_status.rs
@@ -1,0 +1,168 @@
+use graphql_client::GraphQLQuery;
+use log::warn;
+
+use crate::models::{DateTime, Url};
+
+type URI = Url;
+
+#[derive(GraphQLQuery)]
+#[graphql(
+    schema_path = "src/graphql/data/schema.graphql",
+    query_path = "src/graphql/data/check_run_status.graphql",
+    deprecated = "warn",
+    response_derives = "Debug, Clone, PartialEq, Eq"
+)]
+pub struct CheckRunStatusQL;
+
+pub struct RunStatuses {
+    commit_url: Url,
+    committed_at: DateTime,
+    overall_status: Option<check_run_status_ql::StatusState>,
+    checks: Vec<RunStatus>,
+}
+
+pub struct RunStatus {
+    name: String,
+    completed_at: DateTime,
+    result: check_run_status_ql::CheckConclusionState,
+    status: check_run_status_ql::CheckStatusState,
+    is_required: bool,
+}
+
+impl Default for RunStatuses {
+    fn default() -> Self {
+        Self {
+            commit_url: Url::from(""),
+            committed_at: DateTime::default(),
+            overall_status: None,
+            checks: vec![],
+        }
+    }
+}
+
+impl From<check_run_status_ql::ResponseData> for RunStatuses {
+    // these damn nested structs are a nightmare to navigate. Flattening and tidying up into a nicer struct.
+    fn from(res: check_run_status_ql::ResponseData) -> Self {
+        use check_run_status_ql::{
+            CheckRunStatusQlRepository as Repo,
+            CheckRunStatusQlRepositoryPullRequest as PR,
+            CheckRunStatusQlRepositoryPullRequestCommits as C,
+            CheckRunStatusQlRepositoryPullRequestCommitsNodes as CN,
+            CheckRunStatusQlRepositoryPullRequestCommitsNodesCommit as Commit,
+        };
+        let statuses = match res.repository {
+            Some(Repo {
+                pull_request: Some(PR {
+                    commits: C { nodes: Some(v) },
+                }),
+            }) => v,
+            _ => return RunStatuses::default(),
+        };
+        let Commit {
+            url: commit_url,
+            committed_date: committed_at,
+            status_check_rollup,
+            check_suites,
+        } = match statuses.into_iter().next() {
+            Some(Some(CN { commit: c })) => c,
+            _ => return RunStatuses::default(),
+        };
+        let overall_status = status_check_rollup.map(|s| s.state);
+        let checks = match check_suites {
+            Some(cs) => {
+                let checks = cs
+                    .nodes
+                    .into_iter()
+                    .flatten()
+                    .flatten()
+                    .flat_map(|node| {
+                        let app_name = node
+                            .app
+                            .map(|app| app.name)
+                            .unwrap_or_else(|| "App name not provided".to_string());
+                        match node.check_runs {
+                            Some(cr) => {
+                                let run_count = cr.total_count as usize;
+                                let fetched = cr.nodes.iter().flatten().flatten().count();
+                                if run_count != fetched {
+                                    warn!(
+                                        "There are {run_count} check runs for {app_name}, but only {fetched} were \
+                                         fetched. File a bug report saying we need proper pagination in the \
+                                         run_status query code."
+                                    );
+                                }
+                                cr.nodes
+                                    .into_iter()
+                                    .flatten()
+                                    .flatten()
+                                    .map(|run| {
+                                        let name = run.name;
+                                        let completed_at = run.completed_at.unwrap_or_default();
+                                        let result = run.conclusion.unwrap_or_else(|| {
+                                            check_run_status_ql::CheckConclusionState::Other("unknown".to_string())
+                                        });
+                                        let status = run.status;
+                                        let is_required = run.is_required;
+                                        RunStatus {
+                                            name,
+                                            completed_at,
+                                            result,
+                                            status,
+                                            is_required,
+                                        }
+                                    })
+                                    .collect::<Vec<RunStatus>>()
+                            },
+                            None => vec![],
+                        }
+                    })
+                    .collect();
+                checks
+            },
+            None => vec![],
+        };
+
+        RunStatuses {
+            commit_url,
+            committed_at,
+            overall_status,
+            checks,
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::check_run_status_ql::{CheckConclusionState, CheckStatusState, ResponseData, StatusState};
+    use crate::graphql::RunStatuses;
+
+    #[test]
+    fn deserialization() {
+        let json = include_str!("data/sample_check_run.json");
+        let res: ResponseData = serde_json::from_str(json).unwrap();
+        let status = RunStatuses::from(res);
+        assert_eq!(status.overall_status, Some(StatusState::SUCCESS));
+        assert_eq!(
+            status.commit_url.as_ref(),
+            "https://github.com/tari-project/gh-pilot/commit/c13501c51f6a3f5183f5921aa89d68110a29f0f4"
+        );
+        assert_eq!(status.committed_at.to_string(), "2022-09-20T15:30:05Z");
+        assert_eq!(status.checks.len(), 5);
+        let check = &status.checks[0];
+        assert_eq!(check.name, "clippy_check");
+        assert_eq!(check.completed_at.to_string(), "2022-09-20T15:35:54Z");
+        assert!(!check.is_required);
+        assert_eq!(check.result, CheckConclusionState::SUCCESS);
+        assert_eq!(check.status, CheckStatusState::COMPLETED);
+        let check = &status.checks[1];
+        assert_eq!(check.name, "check-title");
+        assert_eq!(check.result, CheckConclusionState::SUCCESS);
+        assert_eq!(check.status, CheckStatusState::COMPLETED);
+        let check = &status.checks[2];
+        assert_eq!(check.name, "cargo test (stable)");
+        let check = &status.checks[3];
+        assert_eq!(check.name, "cargo test (nightly-2022-09-13)");
+        let check = &status.checks[4];
+        assert_eq!(check.name, "check-title");
+    }
+}

--- a/github-api/src/graphql/run_status.rs
+++ b/github-api/src/graphql/run_status.rs
@@ -5,6 +5,7 @@ use log::warn;
 
 use crate::models::{DateTime, Url};
 
+#[allow(clippy::upper_case_acronyms)]
 type URI = Url;
 
 #[derive(GraphQLQuery)]
@@ -89,56 +90,53 @@ impl From<check_run_status_ql::ResponseData> for CheckRunStatus {
         };
         let overall_status = status_check_rollup.map(|s| s.state);
         let checks = match check_suites {
-            Some(cs) => {
-                let checks = cs
-                    .nodes
-                    .into_iter()
-                    .flatten()
-                    .flatten()
-                    .flat_map(|node| {
-                        let app_name = node
-                            .app
-                            .map(|app| app.name)
-                            .unwrap_or_else(|| "App name not provided".to_string());
-                        match node.check_runs {
-                            Some(cr) => {
-                                let run_count = cr.total_count as usize;
-                                let fetched = cr.nodes.iter().flatten().flatten().count();
-                                if run_count != fetched {
-                                    warn!(
-                                        "There are {run_count} check runs for {app_name}, but only {fetched} were \
-                                         fetched. File a bug report saying we need proper pagination in the \
-                                         run_status query code."
-                                    );
-                                }
-                                cr.nodes
-                                    .into_iter()
-                                    .flatten()
-                                    .flatten()
-                                    .map(|run| {
-                                        let name = run.name;
-                                        let completed_at = run.completed_at.unwrap_or_default();
-                                        let result = run.conclusion.unwrap_or_else(|| {
-                                            check_run_status_ql::CheckConclusionState::Other("unknown".to_string())
-                                        });
-                                        let status = run.status;
-                                        let is_required = run.is_required;
-                                        RunStatus {
-                                            name,
-                                            completed_at,
-                                            result,
-                                            status,
-                                            is_required,
-                                        }
-                                    })
-                                    .collect::<Vec<RunStatus>>()
-                            },
-                            None => vec![],
-                        }
-                    })
-                    .collect();
-                checks
-            },
+            Some(cs) => cs
+                .nodes
+                .into_iter()
+                .flatten()
+                .flatten()
+                .flat_map(|node| {
+                    let app_name = node
+                        .app
+                        .map(|app| app.name)
+                        .unwrap_or_else(|| "App name not provided".to_string());
+                    match node.check_runs {
+                        Some(cr) => {
+                            let run_count = cr.total_count as usize;
+                            let fetched = cr.nodes.iter().flatten().flatten().count();
+                            if run_count != fetched {
+                                warn!(
+                                    "There are {run_count} check runs for {app_name}, but only {fetched} were \
+                                     fetched. File a bug report saying we need proper pagination in the run_status \
+                                     query code."
+                                );
+                            }
+                            cr.nodes
+                                .into_iter()
+                                .flatten()
+                                .flatten()
+                                .map(|run| {
+                                    let name = run.name;
+                                    let completed_at = run.completed_at.unwrap_or_default();
+                                    let result = run.conclusion.unwrap_or_else(|| {
+                                        check_run_status_ql::CheckConclusionState::Other("unknown".to_string())
+                                    });
+                                    let status = run.status;
+                                    let is_required = run.is_required;
+                                    RunStatus {
+                                        name,
+                                        completed_at,
+                                        result,
+                                        status,
+                                        is_required,
+                                    }
+                                })
+                                .collect::<Vec<RunStatus>>()
+                        },
+                        None => vec![],
+                    }
+                })
+                .collect(),
             None => vec![],
         };
 

--- a/github-api/src/models/common.rs
+++ b/github-api/src/models/common.rs
@@ -2,7 +2,7 @@ use std::fmt::{Display, Formatter};
 
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Deserialize, Serialize)]
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
 pub struct Url(String);
 
 impl Display for Url {
@@ -14,6 +14,12 @@ impl Display for Url {
 impl AsRef<str> for Url {
     fn as_ref(&self) -> &str {
         self.0.as_str()
+    }
+}
+
+impl<S: Into<String>> From<S> for Url {
+    fn from(s: S) -> Self {
+        Self(s.into())
     }
 }
 

--- a/github-api/src/models/date_time.rs
+++ b/github-api/src/models/date_time.rs
@@ -19,6 +19,12 @@ impl DateTime {
     }
 }
 
+impl Default for DateTime {
+    fn default() -> Self {
+        Self(Timestamp::from_utc(chrono::NaiveDateTime::from_timestamp(0, 0), Utc))
+    }
+}
+
 impl AsRef<Timestamp> for DateTime {
     fn as_ref(&self) -> &Timestamp {
         &self.0

--- a/github-api/src/provider_traits/mod.rs
+++ b/github-api/src/provider_traits/mod.rs
@@ -4,6 +4,11 @@ mod repo_provider;
 mod user_provider;
 
 pub use issue_provider::IssueProvider;
-pub use pull_request_provider::{PullRequestCommentsProvider, PullRequestProvider, PullRequestReviewSummary};
+pub use pull_request_provider::{
+    CheckRunStatusProvider,
+    PullRequestCommentsProvider,
+    PullRequestProvider,
+    PullRequestReviewSummary,
+};
 pub use repo_provider::{Contributors, RepoProvider};
 pub use user_provider::UserProvider;

--- a/github-api/src/provider_traits/pull_request_provider.rs
+++ b/github-api/src/provider_traits/pull_request_provider.rs
@@ -2,7 +2,7 @@ use async_trait::async_trait;
 
 use crate::{
     error::GithubProviderError,
-    graphql::{review_counts::ReviewCounts, PullRequestComments},
+    graphql::{review_counts::ReviewCounts, CheckRunStatus, PullRequestComments},
     models::PullRequest,
     models_plus::{MergeParameters, MergeResult},
     wrappers::IssueId,
@@ -32,4 +32,9 @@ pub trait PullRequestCommentsProvider {
 #[async_trait]
 pub trait PullRequestReviewSummary {
     async fn fetch_review_summary(&self, pr_id: &IssueId) -> Result<ReviewCounts, GithubProviderError>;
+}
+
+#[async_trait]
+pub trait CheckRunStatusProvider {
+    async fn fetch_check_run(&self, pr_id: &IssueId) -> Result<CheckRunStatus, GithubProviderError>;
 }


### PR DESCRIPTION
Adds the `check` sub-command to the pull-request PR command that fetches
the last set of check runs from the last commit on the PR.

Example:

```

ghp-cli -o "tari-project" -r "tari" pull-request -n 4270 check
[2022-10-07T11:38:56Z INFO  ghp_cli] 🚀 Ignition! Launching Github Pilot in Authenticated Mode.
Check Run status for commit https://github.com/tari-project/tari/commit/32987d6d8c4cf768f8962285d625281aea602c74 at 2022-07-14T07:12:30Z
Overall result: "SUCCESS"
┌───────────────────────────────────────────────────────────────────────────────┐
│ Name                Completed At           Result      Status        Required │
│ clippy              2022-07-14T07:20:24Z   "SUCCESS"   "COMPLETED"   true     │
│ check stable        2022-07-14T07:19:53Z   "SUCCESS"   "COMPLETED"   false    │
│ test                2022-07-14T07:12:49Z   "SUCCESS"   "COMPLETED"   true     │
│ check nightly       2022-07-14T07:20:54Z   "SUCCESS"   "COMPLETED"   false    │
│ npm packages        2022-07-14T07:15:42Z   "SUCCESS"   "COMPLETED"   false    │
│ file licenses       2022-07-14T07:12:54Z   "SUCCESS"   "COMPLETED"   false    │
│ test                2022-07-14T07:32:47Z   "SUCCESS"   "COMPLETED"   true     │
│ check-title         2022-07-14T07:13:07Z   "SUCCESS"   "COMPLETED"   true     │
│ integration tests   2022-07-14T07:29:51Z   "SUCCESS"   "COMPLETED"   false    │
└───────────────────────────────────────────────────────────────────────────────┘

```
