### PR TITLE
feat: add auto-merge action

### DIFF
--- a/cli/src/contributors.rs
+++ b/cli/src/contributors.rs
@@ -4,7 +4,7 @@ use log::warn;
 use crate::pretty_print::pretty_table;
 
 pub async fn run_contributor_cmd(provider: &GithubProvider, owner: &str, repo: &str) -> Result<(), ()> {
-    let contributors = provider.get_contributors(owner, repo).await.map_err(|e| {
+    let contributors = provider.fetch_contributors(owner, repo).await.map_err(|e| {
         warn!("⏩ Error fetching contributors: {}", e.to_string());
     })?;
     println!("👀 {} Contributors for {owner}/{repo}:", contributors.len());

--- a/cli/src/pull_request.rs
+++ b/cli/src/pull_request.rs
@@ -80,15 +80,9 @@ async fn merge_pull_request(provider: &dyn PullRequestProvider, id: &IssueId, pa
     match provider.merge_pull_request(id, params.into()).await {
         Ok(r) => {
             if r.merged {
-                info!(
-                    "⏩ PR {}/{}#{} was merged successfully. {}",
-                    id.owner, id.repo, id.number, r.message
-                );
+                info!("⏩ PR {id} was merged successfully. {}", r.message);
             } else {
-                warn!(
-                    "⏩ The PR {}/{}#{} was NOT merged. {}",
-                    id.owner, id.repo, id.number, r.message
-                );
+                warn!("⏩ The PR {id} was NOT merged. {}", r.message);
             }
         },
         Err(e) => warn!("⏩ Error merging PR: {e}"),

--- a/github-api/src/github_provider.rs
+++ b/github-api/src/github_provider.rs
@@ -190,7 +190,7 @@ impl RepoProvider for GithubProvider {
 
 #[async_trait]
 impl Contributors for GithubProvider {
-    async fn get_contributors(&self, owner: &str, repo: &str) -> Result<Vec<Contributor>, GithubProviderError> {
+    async fn fetch_contributors(&self, owner: &str, repo: &str) -> Result<Vec<Contributor>, GithubProviderError> {
         let repo = RepoRequest::new(owner, repo);
         let result = repo.fetch_contributors(&self.client).await?;
         Ok(result)
@@ -200,12 +200,7 @@ impl Contributors for GithubProvider {
 #[async_trait]
 impl PullRequestCommentsProvider for GithubProvider {
     async fn fetch_pull_request_comments(&self, pr_id: &IssueId) -> Result<PullRequestComments, GithubProviderError> {
-        trace!(
-            "⏩ Fetching pull request comments for PR {}/{}#{}",
-            pr_id.owner,
-            pr_id.repo,
-            pr_id.number
-        );
+        trace!("⏩ Fetching pull request comments for PR {pr_id}");
         let pr = PullRequestRequest::new(&pr_id.owner, &pr_id.repo, pr_id.number);
         let result = pr.fetch_comments(&self.client).await?;
         Ok(result)

--- a/github-api/src/graphql/pr_comments.rs
+++ b/github-api/src/graphql/pr_comments.rs
@@ -26,10 +26,22 @@ pub struct CommentThread {
     pub comments: Vec<Comment>,
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize)]
+#[derive(Default, Debug, Clone, Deserialize, Serialize)]
 pub struct PullRequestComments {
     pub comments: Vec<Comment>,
     pub threads: Vec<CommentThread>,
+}
+
+impl PullRequestComments {
+    /// Utility function to add a custom comment to the thread. Primarily used for testing.
+    pub fn add_comment(&mut self, login: &str, comment: &str) -> &mut Self {
+        self.comments.push(Comment {
+            body: comment.to_string(),
+            created_at: DateTime::now(),
+            author: login.into(),
+        });
+        self
+    }
 }
 
 impl From<pull_request_comments_ql::ResponseData> for PullRequestComments {

--- a/github-api/src/graphql/review_counts.rs
+++ b/github-api/src/graphql/review_counts.rs
@@ -114,3 +114,43 @@ impl From<pull_request_review_counts_ql::ResponseData> for ReviewCounts {
         }
     }
 }
+
+#[cfg(test)]
+mod test {
+    use pull_request_review_counts_ql::PullRequestReviewState;
+
+    use super::*;
+
+    #[test]
+    fn review_counts() {
+        let counts = ReviewCounts {
+            total_count: 3,
+            id: IssueId::new("me", "proj", 12),
+            title: "Foom".to_string(),
+            reviews: vec![
+                ReviewSummary {
+                    author: "bob".to_string(),
+                    state: PullRequestReviewState::APPROVED,
+                    created_at: DateTime::now(),
+                },
+                ReviewSummary {
+                    author: "andy".to_string(),
+                    state: PullRequestReviewState::CHANGES_REQUESTED,
+                    created_at: DateTime::now(),
+                },
+                ReviewSummary {
+                    author: "mary".to_string(),
+                    state: PullRequestReviewState::APPROVED,
+                    created_at: DateTime::now(),
+                },
+            ],
+        };
+
+        assert_eq!(counts.total(), 3);
+        assert_eq!(counts.approvals(), 2);
+        assert!(counts.changes_requested());
+        assert_eq!(counts.reviewers(), vec!["bob", "andy", "mary"]);
+        assert_eq!(counts.id(), &IssueId::new("me", "proj", 12));
+        assert_eq!(counts.title(), "Foom");
+    }
+}

--- a/github-api/src/models/date_time.rs
+++ b/github-api/src/models/date_time.rs
@@ -17,6 +17,10 @@ impl DateTime {
     pub fn into_datetime(self) -> Timestamp {
         self.0
     }
+
+    pub fn now() -> Self {
+        Self(Utc::now())
+    }
 }
 
 impl Default for DateTime {

--- a/github-api/src/models/user.rs
+++ b/github-api/src/models/user.rs
@@ -45,7 +45,7 @@ impl ToString for UserType {
     }
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Default, Serialize, Deserialize)]
 pub struct Contributor {
     pub login: String,
     pub id: i64,

--- a/github-api/src/provider_traits/repo_provider.rs
+++ b/github-api/src/provider_traits/repo_provider.rs
@@ -30,5 +30,5 @@ pub trait RepoProvider {
 
 #[async_trait]
 pub trait Contributors {
-    async fn get_contributors(&self, owner: &str, repo: &str) -> Result<Vec<Contributor>, GithubProviderError>;
+    async fn fetch_contributors(&self, owner: &str, repo: &str) -> Result<Vec<Contributor>, GithubProviderError>;
 }

--- a/github-api/src/webhooks/pr_event.rs
+++ b/github-api/src/webhooks/pr_event.rs
@@ -6,6 +6,7 @@ use crate::{
     api::PullRequestRequest,
     models::PullRequest,
     webhooks::{PullRequestAction, PullRequestEvent},
+    wrappers::IssueId,
 };
 
 impl PullRequestEvent {
@@ -27,6 +28,10 @@ impl PullRequestEvent {
 
     pub fn to_request(&self) -> PullRequestRequest {
         PullRequestRequest::new(self.owner(), self.repo(), self.number())
+    }
+
+    pub fn as_issue_id(&self) -> IssueId {
+        IssueId::new(self.owner(), self.repo(), self.number())
     }
 }
 

--- a/github-api/src/wrappers/issue_id.rs
+++ b/github-api/src/wrappers/issue_id.rs
@@ -1,3 +1,8 @@
+use std::{fmt::Display, num::ParseIntError, str::FromStr};
+
+use thiserror::Error;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct IssueId {
     pub owner: String,
     pub repo: String,
@@ -11,5 +16,102 @@ impl IssueId {
             repo: repo.into(),
             number,
         }
+    }
+}
+
+impl Display for IssueId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}/{}#{}", self.owner, self.repo, self.number)
+    }
+}
+
+#[derive(Clone, Debug, Error)]
+pub enum IssueIdParseError {
+    #[error("The issue or pr number was missing. {0}")]
+    MissingNumber(#[from] ParseIntError),
+    #[error("Could not extract repository name from the string.")]
+    MissingRepoSeparator,
+    #[error("The issue or pr string is in the wrong format. {0}")]
+    FormatError(String),
+}
+
+impl FromStr for IssueId {
+    type Err = IssueIdParseError;
+
+    /// Parses a string of the format `{owner}/{repo}#{number}` into an `IssueId`.
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let mut split = s.split('#');
+        let repo = split
+            .next()
+            .ok_or(IssueIdParseError::FormatError("The string was empty".into()))?;
+        let number = split.next().ok_or_else(|| {
+            IssueIdParseError::FormatError("The `#{number}` portion of the string was missing or incomplete".into())
+        })?;
+        let number = number.parse::<u64>()?;
+        let mut split = repo.split('/');
+        let owner = split
+            .next()
+            .ok_or_else(|| IssueIdParseError::FormatError("`{owner}/{repo}` portion missing from string".into()))?;
+        let repo = split.next().ok_or(IssueIdParseError::MissingRepoSeparator)?;
+        Ok(Self {
+            owner: owner.to_string(),
+            repo: repo.to_string(),
+            number,
+        })
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::num::IntErrorKind;
+
+    use crate::wrappers::{issue_id::IssueIdParseError, IssueId};
+
+    #[test]
+    fn parse_id() {
+        let id = "owner/repo#123".parse::<IssueId>().unwrap();
+        assert_eq!(id.owner, "owner");
+        assert_eq!(id.repo, "repo");
+        assert_eq!(id.number, 123);
+    }
+
+    #[test]
+    fn missing_number() {
+        let id = "owner/repo#".parse::<IssueId>();
+        assert!(
+            matches!(id, Err(IssueIdParseError::MissingNumber(ref e)) if e.kind() == &IntErrorKind::Empty),
+            "Expected a MissingNumber, got {:?}",
+            id
+        );
+        let id = "owner/repo#x".parse::<IssueId>();
+        assert!(
+            matches!(id, Err(IssueIdParseError::MissingNumber(ref e)) if e.kind() == &IntErrorKind::InvalidDigit),
+            "Expected a MissingNumber, got {:?}",
+            id
+        );
+    }
+
+    #[test]
+    fn missing_repo() {
+        let id = "#123".parse::<IssueId>();
+        assert!(
+            matches!(id, Err(IssueIdParseError::MissingRepoSeparator)),
+            "Got {:?}",
+            id
+        );
+        let id = "owner#123".parse::<IssueId>();
+        assert!(
+            matches!(id, Err(IssueIdParseError::MissingRepoSeparator)),
+            "Got {:?}",
+            id
+        );
+        let id = "".parse::<IssueId>();
+        assert!(
+            matches!(id, Err(IssueIdParseError::FormatError(ref s))
+                if s == "The `#{number}` portion of the string was missing or incomplete"
+            ),
+            "Got {:?}",
+            id
+        );
     }
 }

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -15,6 +15,7 @@ env_logger = "0.9.0"
 futures = "0.3.21"
 hmac = "0.12.1"
 log = "0.4.17"
+regex = "1.6.0"
 serde = {version = "1.0.142", features = ["derive"] }
 serde_json = "1.0.83"
 sha2 = "0.10.5"

--- a/server/src/actions/github_action.rs
+++ b/server/src/actions/github_action.rs
@@ -121,12 +121,12 @@ impl Actor for GithubActionExecutor {
     }
 
     fn stopping(&mut self, _ctx: &mut Self::Context) -> Running {
-        println!("🐙 Github Action Executor is stopping");
+        debug!("🐙 Github Action Executor is stopping");
         Running::Stop
     }
 
     fn stopped(&mut self, _ctx: &mut Self::Context) {
-        println!("🐙 Github Action Executor has stopped");
+        debug!("🐙 Github Action Executor has stopped");
     }
 }
 

--- a/server/src/actions/merge_action/action_params.rs
+++ b/server/src/actions/merge_action/action_params.rs
@@ -1,0 +1,221 @@
+use log::warn;
+use regex::Regex;
+
+const DEFAULT_ACKS: usize = 3;
+const DEFAULT_REVIEWS: usize = 1;
+const DEFAULT_PATTERNS: [&str; 4] = ["^(ut|t)?ACK$", "^LGTM!?$", "^:?\\+1:?$", "^👍$"];
+const DEFAULT_LABEL: &str = "P-merge";
+
+#[derive(Clone, Debug)]
+pub struct MergeActionParams {
+    acks_required: usize,
+    ack_patterns: Vec<Regex>,
+    reviews_required: usize,
+    all_checks_must_pass: bool,
+    merge_label: String,
+    /// If true, the action will execute the merge automatically IF the auto-merge label is present. If false, the
+    /// action will ADD the auto-merge label if all checks pass.
+    perform_merge: bool,
+}
+
+impl Default for MergeActionParams {
+    fn default() -> Self {
+        MergeActionParams::builder().build()
+    }
+}
+
+impl MergeActionParams {
+    pub fn builder() -> MergeActionParamsBuilder {
+        MergeActionParamsBuilder::new()
+    }
+
+    /// Utility function that tests a comment string against the list of ACK strings to determine if it is a valid ack.
+    pub fn is_ack(&self, comment: &str) -> bool {
+        self.ack_patterns
+            .iter()
+            .any(|pattern| comment.split('\n').any(|line| pattern.is_match(line)))
+    }
+
+    pub fn min_acks_required(&self) -> usize {
+        self.acks_required
+    }
+
+    pub fn min_reviews_required(&self) -> usize {
+        self.reviews_required
+    }
+
+    pub fn all_checks_must_pass(&self) -> bool {
+        self.all_checks_must_pass
+    }
+
+    pub fn merge_label(&self) -> &str {
+        self.merge_label.as_str()
+    }
+
+    pub fn perform_merge(&self) -> bool {
+        self.perform_merge
+    }
+}
+
+#[derive(Default)]
+pub struct MergeActionParamsBuilder {
+    acks_required: Option<usize>,
+    ack_patterns: Option<Vec<Regex>>,
+    reviews_required: Option<usize>,
+    all_checks_must_pass: Option<bool>,
+    merge_label: Option<String>,
+    perform_merge: Option<bool>,
+}
+
+impl MergeActionParamsBuilder {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Sets the number of ACKs required to merge the PR. These are meant to represent reviews from contributors that
+    /// are NOT maintainers of the repository (i.e. they do not have write access to the repository, but have
+    /// contributed at least one merged PR to it).
+    ///
+    /// The [`ack_pattern`]s determine what constitutes a valid ACK.
+    ///
+    /// The default value is 3.
+    pub fn acks_required(mut self, acks_required: usize) -> Self {
+        self.acks_required = Some(acks_required);
+        self
+    }
+
+    /// Adds the given regular expression to the list of patterns that are used to determine if a comment is an ACK.
+    /// By default, the following patterns are used:
+    /// * `[ut]ACK`
+    /// * `LGTM`
+    /// * `[:]+1[:]`
+    /// * `👍`
+    pub fn ack_pattern(mut self, pattern: &str) -> Self {
+        match (Regex::new(pattern), &mut self.ack_patterns) {
+            (Ok(regex), Some(ref mut ack_patterns)) => ack_patterns.push(regex),
+            (Ok(regex), None) => self.ack_patterns = Some(vec![regex]),
+            (Err(e), _) => {
+                warn!("⏫ Invalid merge action ack pattern: \"{pattern}\": {e} . This pattern will be ignored.")
+            },
+        };
+        self
+    }
+
+    /// Sets the minimum number of approved reviews needed to be able to merge the PR. These are "approved" reviews
+    /// given through Github and will be subject to the repo's branch protection rules and the like.
+    /// The default is 1.
+    pub fn reviews_required(mut self, reviews_required: usize) -> Self {
+        self.reviews_required = Some(reviews_required);
+        self
+    }
+
+    /// If true, all checks must pass before the PR can be merged. If false, the PR can be merged even if some checks
+    /// fail.
+    /// The default is `true`.
+    pub fn all_checks_must_pass(mut self, all_checks_must_pass: bool) -> Self {
+        self.all_checks_must_pass = Some(all_checks_must_pass);
+        self
+    }
+
+    /// Define the label that is used to either trigger a merge, or get added to the PR if the PR should be merged.
+    /// The specific action depends on the value of [`perform_merge`].
+    /// The default is `P-merge`.
+    pub fn merge_label(mut self, auto_merge_label: &str) -> Self {
+        self.merge_label = Some(auto_merge_label.into());
+        self
+    }
+
+    /// If true, the action will execute the merge automatically IF the auto-merge label is present. If false, the
+    /// action will ADD the auto-merge label if all checks pass.
+    /// The default is `false`.
+    pub fn perform_merge(mut self, perform_merge: bool) -> Self {
+        self.perform_merge = Some(perform_merge);
+        self
+    }
+
+    /// Builds the [`MergeActionParams`] struct.
+    pub fn build(self) -> MergeActionParams {
+        MergeActionParams {
+            acks_required: self.acks_required.unwrap_or(DEFAULT_ACKS),
+            ack_patterns: self.ack_patterns.unwrap_or_else(default_patterns),
+            reviews_required: self.reviews_required.unwrap_or(DEFAULT_REVIEWS),
+            all_checks_must_pass: self.all_checks_must_pass.unwrap_or(true),
+            merge_label: self.merge_label.unwrap_or_else(|| DEFAULT_LABEL.to_string()),
+            perform_merge: self.perform_merge.unwrap_or(false),
+        }
+    }
+}
+
+fn default_patterns() -> Vec<Regex> {
+    DEFAULT_PATTERNS
+        .iter()
+        .map(|&pattern| Regex::new(pattern).unwrap())
+        .collect()
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn default_params() {
+        let params = MergeActionParams::default();
+        assert_eq!(params.acks_required, DEFAULT_ACKS);
+        assert_eq!(params.reviews_required, DEFAULT_REVIEWS);
+        assert!(params.all_checks_must_pass);
+        assert_eq!(params.merge_label, DEFAULT_LABEL);
+        assert_eq!(params.perform_merge, false);
+    }
+
+    #[test]
+    fn default_ack_patterns() {
+        let params = MergeActionParams::default();
+        assert!(params.is_ack("ACK"));
+        assert!(params.is_ack("utACK"));
+        // NOT valid acks:
+        assert!(!params.is_ack("STACK"));
+        assert!(!params.is_ack("RACK up points"));
+        assert!(!params.is_ack("This pr makes me ACK"));
+
+        assert!(params.is_ack("LGTM"));
+        assert!(params.is_ack("LGTM!"));
+        // NOT valid acks:
+        assert!(!params.is_ack("LGTM, not!"));
+        assert!(!params.is_ack("LGTMBQ-friendly"));
+
+        assert!(params.is_ack(":+1:"));
+        assert!(params.is_ack("+1"));
+        assert!(params.is_ack("👍"));
+        // NOT valid acks:
+        assert!(!params.is_ack("👎"));
+        assert!(!params.is_ack("well, 1+1=2, so.."));
+        assert!(!params.is_ack("👍 or 👎 below"));
+        // multiline acks are ok:
+        assert!(params.is_ack("Some nits, but looks great.\n👍"));
+
+        // Other invalid ACKS
+        assert!(!params.is_ack("\n\n\n\n"));
+    }
+
+    #[test]
+    fn builder() {
+        let params = MergeActionParamsBuilder::new()
+            .acks_required(5)
+            .ack_pattern("Foo")
+            .ack_pattern("b[aA]r")
+            .reviews_required(21)
+            .all_checks_must_pass(false)
+            .merge_label("BAZ")
+            .perform_merge(true)
+            .build();
+
+        assert_eq!(params.acks_required, 5);
+        assert_eq!(params.reviews_required, 21);
+        assert_eq!(params.all_checks_must_pass, false);
+        assert_eq!(params.merge_label, "BAZ");
+        assert!(params.perform_merge);
+        // why you should be careful when defining your own ack parameters:
+        assert!(params.is_ack("Food"));
+        assert!(params.is_ack("My barometer"));
+    }
+}

--- a/server/src/actions/merge_action/executor.rs
+++ b/server/src/actions/merge_action/executor.rs
@@ -1,0 +1,363 @@
+use std::sync::Arc;
+
+use actix::{Actor, Context, Handler, ResponseFuture, Running, Supervised, SystemService};
+use github_pilot_api::{
+    error::GithubProviderError,
+    graphql::{run_status::check_run_status_ql, CheckRunStatus, PullRequestComments},
+    models_plus::{MergeMethod, MergeParameters},
+    provider_traits::{
+        CheckRunStatusProvider,
+        Contributors,
+        IssueProvider,
+        PullRequestCommentsProvider,
+        PullRequestProvider,
+        PullRequestReviewSummary,
+    },
+    wrappers::IssueId,
+    GithubProvider,
+};
+use log::*;
+
+use crate::actions::merge_action::{message::MergeActionMessage, MergeActionParams};
+
+#[derive(Clone)]
+pub struct MergeExecutor {
+    provider: Arc<dyn PullRequestProvider>,
+    comments: Arc<dyn PullRequestCommentsProvider>,
+    reviews: Arc<dyn PullRequestReviewSummary>,
+    contributors: Arc<dyn Contributors>,
+    checks: Arc<dyn CheckRunStatusProvider>,
+    issues: Arc<dyn IssueProvider>,
+}
+
+impl Default for MergeExecutor {
+    fn default() -> Self {
+        let provider = Arc::new(GithubProvider::default());
+        MergeExecutor {
+            provider: provider.clone(),
+            comments: provider.clone(),
+            reviews: provider.clone(),
+            contributors: provider.clone(),
+            checks: provider.clone(),
+            issues: provider,
+        }
+    }
+}
+
+impl MergeExecutor {
+    pub fn new(
+        provider: Arc<dyn PullRequestProvider>,
+        comments: Arc<dyn PullRequestCommentsProvider>,
+        reviews: Arc<dyn PullRequestReviewSummary>,
+        contributors: Arc<dyn Contributors>,
+        checks: Arc<dyn CheckRunStatusProvider>,
+        issues: Arc<dyn IssueProvider>,
+    ) -> Self {
+        MergeExecutor {
+            provider,
+            comments,
+            reviews,
+            contributors,
+            checks,
+            issues,
+        }
+    }
+
+    /// Obtains a list of contributors from the [`Contributors`] provider.
+    async fn fetch_contributors(&self, id: &IssueId) -> Result<Vec<String>, GithubProviderError> {
+        let contributors = self
+            .contributors
+            .fetch_contributors(id.owner.as_str(), id.repo.as_str())
+            .await?;
+        Ok(contributors.into_iter().map(|c| c.login).collect())
+    }
+
+    /// Checks that the PR comments contain enough ACK comments from contributors
+    async fn check_acks(&self, params: &MergeActionParams, id: &IssueId, contributors: Vec<String>) -> bool {
+        let comments = match self.comments.fetch_pull_request_comments(id).await {
+            Ok(comments) => comments,
+            Err(e) => {
+                warn!("⏫ Could not check ACK count because we could not get comments for PR {id}. {e}");
+                return false;
+            },
+        };
+        trace!("⏫ PR {id} has {} comments", comments.comments.len());
+        let num_acks = Self::count_acks_sync(params, contributors, comments);
+        debug!(
+            "⏫ PR {id} has {num_acks} / {} required ACKs",
+            params.min_acks_required()
+        );
+        num_acks >= params.min_acks_required()
+    }
+
+    // sync function to make it easier to test
+    fn count_acks_sync(
+        params: &MergeActionParams,
+        mut contributors: Vec<String>,
+        comments: PullRequestComments,
+    ) -> usize {
+        // Ignoring review comment threads for ACKS
+        let num_acks = comments
+            .comments
+            .iter()
+            .filter(|&c| {
+                if !params.is_ack(c.body.as_str()) {
+                    return false;
+                }
+                if let Some(i) = contributors.iter().position(|u| u == &c.author) {
+                    // A contributor can only ACK once
+                    contributors.remove(i);
+                    true
+                } else {
+                    false
+                }
+            })
+            .count();
+        num_acks
+    }
+
+    /// Checks whether the minimum number of reviews from maintainers have been submitted. If changes have been
+    /// requested, this method always returns false.
+    async fn check_reviews(&self, params: &MergeActionParams, id: &IssueId) -> bool {
+        let reviews = match self.reviews.fetch_review_summary(id).await {
+            Ok(reviews) => reviews,
+            Err(e) => {
+                warn!("👀 Could not check review count because we could not get reviews for PR {id}. {e}");
+                return false;
+            },
+        };
+        let approved = reviews.approvals();
+        let change_req = reviews.changes_requested();
+        let required = params.min_reviews_required();
+        let total = reviews.total();
+        debug!("👀 PR {id} has {total} reviews, {approved}/{required} required, changes_requested: {change_req}");
+        !change_req && approved >= required
+    }
+
+    /// Checks whether the branch protection checks have passed yet
+    async fn checks_passed(&self, params: &MergeActionParams, id: &IssueId) -> bool {
+        if !params.all_checks_must_pass() {
+            return true;
+        }
+        let checks = match self.checks.fetch_check_run(id).await {
+            Ok(checks) => checks,
+            Err(e) => {
+                warn!("⏫ Could not check check run status because we could not get checks for PR {id}. {e}");
+                return false;
+            },
+        };
+        trace!("⏫ Checking status of last Check Run for PR {id}");
+        Self::have_all_required_checks_passed(&checks)
+    }
+
+    // Check that all _required_ checks have passed successfully
+    fn have_all_required_checks_passed(checks: &CheckRunStatus) -> bool {
+        // First look at the rollup status
+        match checks.overall_status() {
+            Some(check_run_status_ql::StatusState::SUCCESS) => {
+                debug!("⏫ Github reports that the rolled up status of the PR checks is SUCCESS");
+                true
+            },
+            Some(check_run_status_ql::StatusState::FAILURE) => {
+                debug!("⏫ Github reports that the rolled up status of the PR checks is FAILURE");
+                false
+            },
+            _ => checks
+                .checks()
+                .filter(|run| run.is_required)
+                .all(|run| matches!(run.result, check_run_status_ql::CheckConclusionState::SUCCESS)),
+        }
+    }
+
+    /// Carries out the merge action. The action depends on the state of `[MergeActionParams::auto-merge]`.
+    async fn execute_merge_action(&self, params: &MergeActionParams, id: &IssueId) {
+        if params.perform_merge() {
+            self.merge_pr(id).await;
+        } else {
+            self.add_label(id, params.merge_label()).await;
+        }
+    }
+
+    async fn merge_pr(&self, id: &IssueId) {
+        let params = MergeParameters {
+            merge_method: MergeMethod::Squash,
+            ..Default::default()
+        };
+        match self.provider.merge_pull_request(id, params).await {
+            Ok(_) => info!("⏫ Merged PR {id}. Thank you for using AutoMerge™"),
+            Err(e) => warn!("⏫ Could not merge PR {id}. {e}"),
+        }
+    }
+
+    async fn add_label(&self, id: &IssueId, label: &str) {
+        match self.issues.add_label(id, label).await {
+            Ok(_) => info!("⏫ Added label {label} to PR {id}. Thank you for using AutoMerge™"),
+            Err(e) => warn!("⏫ Could not add label {label} to PR {id}. {e}"),
+        }
+    }
+}
+
+impl Actor for MergeExecutor {
+    type Context = Context<Self>;
+
+    fn started(&mut self, _ctx: &mut Self::Context) {
+        debug!("⏫ MergeExecutor started");
+    }
+
+    fn stopping(&mut self, _ctx: &mut Self::Context) -> Running {
+        debug!("⏫ MergeExecutor stopping");
+        Running::Stop
+    }
+
+    fn stopped(&mut self, _ctx: &mut Self::Context) {
+        debug!("⏫ MergeExecutor stopped");
+    }
+}
+
+impl Supervised for MergeExecutor {}
+
+impl SystemService for MergeExecutor {}
+
+impl Handler<MergeActionMessage> for MergeExecutor {
+    type Result = ResponseFuture<()>;
+
+    fn handle(&mut self, msg: MergeActionMessage, _ctx: &mut Self::Context) -> Self::Result {
+        let this = self.clone();
+        let fut = async move {
+            let MergeActionMessage {
+                name,
+                event_name,
+                event,
+                params,
+            } = msg;
+            debug!("⏫ MergeExecutor handler is running task \"{name}\" for event \"{event_name}\"");
+            trace!("   on github event: {}", event.summary());
+            let id = match event.pull_request() {
+                Some(pr) => pr.as_issue_id(),
+                None => return,
+            };
+            let contributors = match this.fetch_contributors(&id).await {
+                Ok(contributors) => contributors,
+                Err(e) => {
+                    warn!("⏫ Merge action could not get the list of contributors for PR {id}. {e}");
+                    return;
+                },
+            };
+            if this.check_acks(&params, &id, contributors).await &&
+                this.check_reviews(&params, &id).await &&
+                this.checks_passed(&params, &id).await
+            {
+                this.execute_merge_action(&params, &id).await;
+            }
+        };
+        Box::pin(fut)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use async_trait::async_trait;
+    use github_pilot_api::{
+        error::GithubProviderError,
+        graphql::PullRequestComments,
+        models::Contributor,
+        provider_traits::Contributors,
+    };
+
+    use crate::actions::merge_action::{MergeActionParams, MergeExecutor};
+
+    pub struct MockProvider {
+        contributors: Vec<String>,
+    }
+
+    impl MockProvider {
+        pub fn new<S: Into<String>>(contributors: Vec<S>) -> Self {
+            MockProvider {
+                contributors: contributors.into_iter().map(|s| s.into()).collect(),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl Contributors for MockProvider {
+        async fn fetch_contributors(&self, _owner: &str, _repo: &str) -> Result<Vec<Contributor>, GithubProviderError> {
+            let contributors = self
+                .contributors
+                .iter()
+                .map(|c| Contributor {
+                    login: c.clone(),
+                    ..Default::default()
+                })
+                .collect();
+            Ok(contributors)
+        }
+    }
+
+    #[tokio::test]
+    async fn fetch_contributors() {
+        let provider = MockProvider::new(vec!["foo", "bar"]);
+        let contributors = provider.fetch_contributors("owner", "repo").await.unwrap();
+        assert_eq!(contributors.len(), 2);
+        assert_eq!(contributors[0].login, "foo");
+        assert_eq!(contributors[1].login, "bar");
+    }
+
+    #[test]
+    fn basic_acks() {
+        let params = MergeActionParams::default();
+        let mut comments = PullRequestComments::default();
+        comments
+            .add_comment("bob", "Hi")
+            .add_comment("alice", "ACK")
+            .add_comment("steve", "ACK")
+            .add_comment("che", ":+1:")
+            .add_comment("bob", "👍");
+        let contributors = ["alice", "bob", "che"]
+            .into_iter()
+            .map(String::from)
+            .collect::<Vec<String>>();
+        assert_eq!(MergeExecutor::count_acks_sync(&params, contributors, comments), 3);
+    }
+
+    #[test]
+    fn sybil_attack() {
+        let params = MergeActionParams::default();
+        let mut comments = PullRequestComments::default();
+        comments
+            .add_comment("bob", "utACK")
+            .add_comment("bob", "ACK")
+            .add_comment("bob", "👍");
+        let contributors = vec!["bob".into()];
+        assert_eq!(MergeExecutor::count_acks_sync(&params, contributors, comments), 1);
+    }
+
+    #[test]
+    fn empty_vecs() {
+        let params = MergeActionParams::default();
+        let mut comments = PullRequestComments::default();
+        comments.add_comment("bob", "ACK");
+        let contributors = vec!["bob".into()];
+        assert_eq!(MergeExecutor::count_acks_sync(&params, vec![], comments), 0);
+        assert_eq!(
+            MergeExecutor::count_acks_sync(&params, contributors, PullRequestComments::default()),
+            0
+        );
+    }
+
+    #[test]
+    fn ambiguous_comments() {
+        let params = MergeActionParams::default();
+        let mut comments = PullRequestComments::default();
+        comments
+            .add_comment("alice", "Hi I'm BACK!")
+            .add_comment("bob", "ACK")
+            .add_comment("bob1", "ACK")
+            .add_comment("rando", ":+1:")
+            .add_comment("che", "Really good\n👍");
+        let contributors = ["alice", "bob", "che"]
+            .into_iter()
+            .map(String::from)
+            .collect::<Vec<String>>();
+        assert_eq!(MergeExecutor::count_acks_sync(&params, contributors, comments), 2);
+    }
+}

--- a/server/src/actions/merge_action/message.rs
+++ b/server/src/actions/merge_action/message.rs
@@ -1,0 +1,43 @@
+use actix::Message;
+use github_pilot_api::webhooks::GithubEvent;
+
+use crate::actions::merge_action::action_params::MergeActionParams;
+
+#[derive(Clone)]
+pub struct MergeActionMessage {
+    pub name: String,
+    pub event_name: String,
+    pub event: GithubEvent,
+    pub params: MergeActionParams,
+}
+
+impl MergeActionMessage {
+    pub fn new<S: Into<String>>(name: S, event_name: S, event: GithubEvent, params: MergeActionParams) -> Self {
+        MergeActionMessage {
+            name: name.into(),
+            event_name: event_name.into(),
+            event,
+            params,
+        }
+    }
+
+    pub fn name(&self) -> &str {
+        self.name.as_str()
+    }
+
+    pub fn event_name(&self) -> &str {
+        self.event_name.as_str()
+    }
+
+    pub fn event(&self) -> &GithubEvent {
+        &self.event
+    }
+
+    pub fn params(&self) -> &MergeActionParams {
+        &self.params
+    }
+}
+
+impl Message for MergeActionMessage {
+    type Result = ();
+}

--- a/server/src/actions/merge_action/mod.rs
+++ b/server/src/actions/merge_action/mod.rs
@@ -19,6 +19,6 @@ mod action_params;
 mod executor;
 mod message;
 
-pub use action_params::MergeActionParams;
+pub use action_params::{MergeActionParams, MergeActionParamsBuilder};
 pub use executor::MergeExecutor;
 pub use message::MergeActionMessage;

--- a/server/src/actions/merge_action/mod.rs
+++ b/server/src/actions/merge_action/mod.rs
@@ -1,0 +1,24 @@
+//! # The Github Pilot merge action
+//!
+//! An action for controlling automatic merges with Github Pilot.
+//!
+//! In general the merge flow goes as follows:
+//! 1. The action is triggered by a webhook event, e.g. a PR, or label being added etc. This can be set up in
+//! different ways, but if you require a manual review step at some point (recommended), then you may want to trigger
+//! this action when a `P-approved` label or similar is added to a PR.
+//! 2. The action can be configured to perform a number of checks:
+//!   a. Check that the PR is mergeable, according to Github.
+//!   b. Check that the required number of "ACK", or "+1" comments have been made by known contributors.
+//!   c. Check that the required number of approving reviews have been made by maintainers.
+//!   d. Check that the required "auto-merge" label is present (can be the same label that triggers this action).
+//! 3. If all but 2a pass, you can _try_ to update and rebase the branch to make it mergeable using the
+//!    [`AutoUpdate`] action.
+//! 4. If all checks pass, the PR is merged using the merge strategy defined in the [`MergeAction`].
+
+mod action_params;
+mod executor;
+mod message;
+
+pub use action_params::MergeActionParams;
+pub use executor::MergeExecutor;
+pub use message::MergeActionMessage;

--- a/server/src/actions/mod.rs
+++ b/server/src/actions/mod.rs
@@ -6,22 +6,22 @@
 //!
 //! To write a new Action implementation, you need to do the following
 //!  - Define a new struct that implements [`actix::Actor`], `MyHotActionExecutor`, say.
-//!  - Define a new struct, `MyHotAction` that completely defines what inputs `MyHotActionExecutor` needs to execute the
-//!    task. By convention, the message structs are suffixed with `Action` since this is what is used in the Rule API.
-//!  - Mark `MyHotAction` with the [`essentials::Action`] marker trait so that it can be used in [`crate::rules::Rule`]
-//!    definitions.
+//!  - Define a new struct, `MyHotActionParams` that completely defines what inputs `MyHotActionExecutor` needs to
+//!    execute the task.
 //!  - You'll also need a `MyHotActionMessage` struct that implements [`actix:Message`]. This struct must collect the
-//!    data from `MyHotAction` (or even the entire struct) and combine it with the github event that's relvant to the
-//!    executor. This usually will include the event struct itself.
-//!  - Add any convenience constructors on `MyHotAction` to provide a beautiful API to rule writers.
+//!    data from `MyHotActionParams` (or even the entire struct) and combine it with the github event that's relevant to
+//!    the executor. This usually will include the event struct itself.
+//!  - Add any convenience constructors on `MyHotActionParams` to provide a beautiful API to rule writers.
 //!  - Write a message handler for `MyHotActionMessage` in `MyHotActionExecutor`
-//!  - Add `MyHotActionExecutor` as a field in the `Executor` struct in PubSubActor.
-//!  - Register a `MyHotActionExecutor` instance with the PubSub Actor in server.rs
+//!  - Add `MyHotAction` as a field in the [`essentials::Actions`] enum using `MyHotActionParams` as the variant type.
+//!  - Handle the new action type in [`PubSubActor::dispatch_message`].
 
 mod closure_action;
 mod essentials;
 mod github_action;
+mod merge_action;
 
 pub use closure_action::{ClosureActionExecutor, ClosureActionMessage, ClosureActionParams};
 pub use essentials::Actions;
 pub use github_action::{GithubActionExecutor, GithubActionMessage, GithubActionParams};
+pub use merge_action::{MergeActionMessage, MergeActionParams, MergeExecutor};

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -92,6 +92,16 @@ mod rules {
                     .execute(action)
                     .submit()
             },
+            RuleBuilder::new("AutoMerge™")
+                .when(PullRequest::labeled_with("P-merge"))
+                // .when( PullRequest::approved()) <- TODO add this predicate
+                // .when(PullRequestComment::added()) <- TODO add this predicate
+                // .when(CheckRunComplete::success()) <- TODO add this predicate
+                .execute(Actions::auto_merge()
+                    .with_min_acks(1)
+                    .with_min_reviews(0)
+                    .build())
+                .submit(),
         ];
 
         let msg = ReplaceRulesMessage { new_rules: rules };


### PR DESCRIPTION
`merge_action` is a Github Pilot action that can automatically merge PRs based on given criteria.

This is a very basic version of this action, and will not be as full-featured as some other products like merge-queue, or bors; but, using other actions, and labels as a messaging system, you _can_ build up some fairly complex behaviour.

I'll also add additional features to this action in future, after allowing for a decent period to get feedback on how this action is performing.

This action is the most complex written to date, so it has its own module, rather than putting everything in one file.

### Merge Action Parameters

The merge action behaviour is controlled with these parameters:

 *  acks_required: how many ACK-type messages are required,
 *  ack_patterns: A list of regex patterns to identify as ACK messages,
 *  reviews_required: how many approvals are needed,
 *  all_checks_must_pass: override Github's Run Check status by setting this to false,
 *  merge_label: A label that determines the merge behaviour,
 * perform_merge: When true, the action will execute the merge automatically IF the `merge_label` label is attached to the PR. When false, the action will ADD the merge label.

The builder has a sane set of defaults: 3 ACKS, 1 Review, all checks must pass. The default merge label is `P-merge`, and it is added to the PR by default, rather than auto-merging.

The default ACK regexes are `^(ut|t)?ACK$`, `^LGTM!?$`, `^:?\\+1:?$`, 👍

### Executor

Adds a MergeAction executor type that holds references to trait implementtors for fetching comments, contributors and pushing GH actions. This makes it easy to test, although the **default** implementation (needed for the Actix SystemService) will build a HTTP client using envars for authentication credentials.

### Other features

* Adds IssueId parser
* Adds tests for IssueId parser
* Implements the logic to pull the PR reviews from the provider and decide whether the PR can be merged based on # of approvals > min, and whether changes were requested.