### PR TITLE
feat: improve logs in merge action status feedback

### DIFF
--- a/github-api/src/wrappers/issue_id.rs
+++ b/github-api/src/wrappers/issue_id.rs
@@ -43,7 +43,7 @@ impl FromStr for IssueId {
         let mut split = s.split('#');
         let repo = split
             .next()
-            .ok_or(IssueIdParseError::FormatError("The string was empty".into()))?;
+            .ok_or_else(|| IssueIdParseError::FormatError("The string was empty".into()))?;
         let number = split.next().ok_or_else(|| {
             IssueIdParseError::FormatError("The `#{number}` portion of the string was missing or incomplete".into())
         })?;


### PR DESCRIPTION
The review check function now gives better feedback in the logs as to its decision.

Example:
```
[...] ⏫ PR tari-project/gh-pilot#27 has 1 comments
[...] ⏫ PR tari-project/gh-pilot#27 has 1 / 1 required ACKs
[...] 👀 PR tari-project/gh-pilot#27 has 0 reviews, 0/0 required, changes_requested: false
[...] ⏫ Checking status of last Check Run for PR tari-project/gh-pilot#27
[...] ⏫ The roll up status is Some(PENDING)
[...] ⏫ PR has 6 checks, 3 passed / 5 required.
```