### PR TITLE
fix: extract related pr in merge action

### DIFF
--- a/github-api/src/github_event.rs
+++ b/github-api/src/github_event.rs
@@ -15,6 +15,7 @@ use crate::{
         PushEvent,
         StatusEvent,
     },
+    wrappers::IssueId,
 };
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -122,6 +123,24 @@ impl GithubEvent {
         match &self {
             Self::PullRequest(pr) => Some(pr),
             _ => None,
+        }
+    }
+
+    /// If this event is related to a pull request, this method conveniently returns the PR details as an [`IssueId`].
+    pub fn related_pull_request(&self) -> Option<IssueId> {
+        match &self {
+            GithubEvent::CheckSuiteEvent(ev) => ev.first_related_pr(),
+            GithubEvent::PullRequest(ev) => Some(ev.as_issue_id()),
+            GithubEvent::PullRequestReview(ev) => Some(ev.related_pull_request()),
+            GithubEvent::PullRequestReviewComment(ev) => Some(ev.related_pull_request()),
+            GithubEvent::Push(_) => None,
+            GithubEvent::Status(_) => None,
+            GithubEvent::Label(_) => None,
+            GithubEvent::CommitComment(_) => None,
+            GithubEvent::IssueComment(_) => None,
+            GithubEvent::Issues(_) => None,
+            GithubEvent::Ping(_) => None,
+            GithubEvent::UnknownEvent { .. } => None,
         }
     }
 }

--- a/github-api/src/models/pull_request.rs
+++ b/github-api/src/models/pull_request.rs
@@ -71,7 +71,7 @@ pub struct PullRequest {
     pub review_comment_url: Url,
     pub comments_url: Url,
     pub statuses_url: Url,
-    pub number: usize,
+    pub number: u64,
     pub state: State,
     pub locked: bool,
     pub title: String,
@@ -128,8 +128,8 @@ pub struct IssuePullRequest {
 pub struct CheckRunPullRequest {
     pub base: GitReferenceShort,
     pub head: GitReferenceShort,
-    pub id: usize,
-    pub number: usize,
+    pub id: u64,
+    pub number: u64,
     pub url: Url,
 }
 

--- a/github-api/src/models/status_check_events.rs
+++ b/github-api/src/models/status_check_events.rs
@@ -115,26 +115,6 @@ impl ToString for CheckSuiteStatus {
     }
 }
 
-impl CheckSuite {
-    pub fn summary(&self) -> String {
-        let prs = self
-            .pull_requests
-            .iter()
-            .map(|pr| format!("PR#{}", pr.id))
-            .collect::<Vec<String>>();
-        let status = self.status.map(|s| s.to_string()).unwrap_or_else(|| "N/A".to_string());
-        let conclusion = self
-            .conclusion
-            .map(|c| c.to_string())
-            .unwrap_or_else(|| "N/A".to_string());
-        format!(
-            "Check suite {} for PRs {} {status}: {conclusion}",
-            self.id,
-            prs.join(",")
-        )
-    }
-}
-
 #[cfg(test)]
 mod test {
     use crate::{

--- a/github-api/src/models_plus/check_suite_event.rs
+++ b/github-api/src/models_plus/check_suite_event.rs
@@ -1,0 +1,63 @@
+use log::{debug, trace};
+
+use crate::{
+    models::{CheckSuite, CheckSuiteEvent},
+    wrappers::IssueId,
+};
+
+impl CheckSuite {
+    pub fn summary(&self) -> String {
+        let prs = self
+            .pull_requests
+            .iter()
+            .map(|pr| format!("PR#{}", pr.id))
+            .collect::<Vec<String>>();
+        let status = self.status.map(|s| s.to_string()).unwrap_or_else(|| "N/A".to_string());
+        let conclusion = self
+            .conclusion
+            .map(|c| c.to_string())
+            .unwrap_or_else(|| "N/A".to_string());
+        format!(
+            "Check suite {} for PRs {} {status}: {conclusion}",
+            self.id,
+            prs.join(",")
+        )
+    }
+}
+
+impl CheckSuiteEvent {
+    /// Returns the set of associated PRs as a vector of IssueId
+    pub fn related_pull_requests(&self) -> Vec<IssueId> {
+        let owner = match self.info.organization {
+            Some(ref org) => org.login.as_str(),
+            None => {
+                trace!(
+                    "No organization was attached in the check suite event, so can't pull owner. If this is an issue, \
+                     we _could_ try extract the info from the pr url field, but that's obviously a bit brittle."
+                );
+                return vec![];
+            },
+        };
+        let repo = self.info.repository.name.as_str();
+        self.check_suite
+            .pull_requests
+            .iter()
+            .map(|pr| IssueId::new(owner, repo, pr.number))
+            .collect()
+    }
+
+    pub fn first_related_pr(&self) -> Option<IssueId> {
+        let prs = self.related_pull_requests();
+        match prs.len() {
+            0 => None,
+            1 => prs.first().cloned(),
+            _ => {
+                debug!(
+                    "CheckSuiteEvent related to multiple PRs: {:?}. Returning the first one",
+                    prs.len()
+                );
+                prs.first().cloned()
+            },
+        }
+    }
+}

--- a/github-api/src/models_plus/mod.rs
+++ b/github-api/src/models_plus/mod.rs
@@ -1,8 +1,11 @@
 //! This module provides additional functionality and helper functions to the structs in the `models` module.
 //! The code is kept separate to avoid messing with the code generation tools.
 
+mod check_suite_event;
 mod deserializers;
 mod pull_request;
 mod pull_request_event;
+mod pull_request_review_comment_event;
+mod pull_request_review_event;
 pub use deserializers::*;
 pub use pull_request::*;

--- a/github-api/src/models_plus/pull_request_review_comment_event.rs
+++ b/github-api/src/models_plus/pull_request_review_comment_event.rs
@@ -1,0 +1,10 @@
+use crate::{models::PullRequestReviewCommentEvent, wrappers::IssueId};
+
+impl PullRequestReviewCommentEvent {
+    pub fn related_pull_request(&self) -> IssueId {
+        let owner = self.info.repository.owner.login.as_str();
+        let repo = self.info.repository.name.as_str();
+        let number = self.pull_request.number;
+        IssueId::new(owner, repo, number)
+    }
+}

--- a/github-api/src/models_plus/pull_request_review_event.rs
+++ b/github-api/src/models_plus/pull_request_review_event.rs
@@ -1,0 +1,10 @@
+use crate::{models::PullRequestReviewEvent, wrappers::IssueId};
+
+impl PullRequestReviewEvent {
+    pub fn related_pull_request(&self) -> IssueId {
+        let owner = self.info.repository.owner.login.as_str();
+        let repo = self.info.repository.name.as_str();
+        let number = self.pull_request.number;
+        IssueId::new(owner, repo, number)
+    }
+}

--- a/server/src/actions/merge_action/executor.rs
+++ b/server/src/actions/merge_action/executor.rs
@@ -265,10 +265,16 @@ impl Handler<MergeActionMessage> for MergeExecutor {
                 params,
             } = msg;
             debug!("⏫ MergeExecutor handler is running task \"{name}\" for event \"{event_name}\"");
-            trace!("   on github event: {}", event.summary());
-            let id = match event.pull_request() {
-                Some(pr) => pr.as_issue_id(),
-                None => return,
+            trace!("⏫ on github event: {}", event.summary());
+            let id = match event.related_pull_request() {
+                Some(pr) => {
+                    debug!("⏫ Extracted pull request details for {pr}");
+                    pr
+                },
+                None => {
+                    debug!("⏫ Could not find a related pull request for event {event_name}");
+                    return;
+                },
             };
             let contributors = match this.fetch_contributors(&id).await {
                 Ok(contributors) => contributors,


### PR DESCRIPTION
Merge Action won't always be triggered on a PR event. But if we can, we should still try and merge the PR if the conditions match. This means extracting the related PR for the event.

This PR adds a `related_pr` method to GithubEvent which tries to dig out the PR info from the different event types.