### PR TITLE
test: speed up gha

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - stable
+#          - stable
           - nightly-2022-09-13
     steps:
       - name: checkout
@@ -23,10 +23,10 @@ jobs:
           profile: minimal
           toolchain: ${{ matrix.rust }}
           override: true
-      - name: test/debug
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
+#      - name: test/debug
+#        uses: actions-rs/cargo@v1
+#        with:
+#          command: test
       - name: test/release
         uses: actions-rs/cargo@v1
         with:


### PR DESCRIPTION
Drop the stable rust, and only test in release mode.