### PR TITLE
feat: actions return a result

### DIFF
--- a/server/src/actions/closure_action.rs
+++ b/server/src/actions/closure_action.rs
@@ -102,18 +102,12 @@ impl Handler<ClosureActionMessage> for ClosureActionExecutor {
                 f(event_name, event);
             })
             .await;
-            let result = match result {
-                Ok(()) => {
-                    debug!("📝 Closure Task completely happily.");
-                    ActionResult::Success
-                },
-                Err(e) => {
-                    debug!("📝 Closure task wasn't happy. {e}");
-                    ActionResult::Failed
-                },
-            };
             debug!("📝 Completed execution of task \"{}\"", name);
-            result
+            ActionResult::from_result(
+                result,
+                || debug!("📝 Closure Task completely happily."),
+                |e| debug!("📝 Closure task wasn't happy. {e}"),
+            )
         })
     }
 }

--- a/server/src/actions/essentials.rs
+++ b/server/src/actions/essentials.rs
@@ -8,19 +8,6 @@ use crate::actions::{
     MergeActionParams,
 };
 
-// Implementation notes: --
-// Actions must actually be Actors. This lets them have state. Then the action tasks will be messages that are
-// sent to the TaskRunner and distributed to the handling actors.
-//
-// webhook msg -> PubSub, checks rules.
-// For each rule triggered,
-// for each actor action referenced in `execute`,
-// build an action task message
-// send it to the relevant action actor
-//
-// action task message -> ActionTask Actor
-// Run task according to specification
-
 #[derive(Clone)]
 pub enum Actions {
     AutoMerge(Box<MergeActionParams>),

--- a/server/src/actions/github_action.rs
+++ b/server/src/actions/github_action.rs
@@ -176,12 +176,11 @@ impl GithubActionExecutor {
         );
         let req = IssueId::new(owner, repo, issue_number);
         let res = provider.add_label(&req, label).await;
-        if let Err(e) = res {
-            warn!("🐙🏷 Failed to add label to issue: {e}");
-            ActionResult::Failed
-        } else {
-            ActionResult::Success
-        }
+        ActionResult::from_result(
+            res,
+            || info!("🐙🏷 Added label {label} to issue {req}"),
+            |e| warn!("🐙🏷 Failed to add label to issue {req}: {e}"),
+        )
     }
 
     async fn remove_label_from_issue(
@@ -211,13 +210,11 @@ impl GithubActionExecutor {
         let id = IssueId::new(event.owner(), event.repo(), event.number());
         debug!("🐙🏷 Adding label {label} to PR {id}");
         let res = provider.add_label(&id, label).await;
-        if let Err(e) = res {
-            warn!("🐙🏷 Failed to add label to PR {id}: {e}");
-            ActionResult::Failed
-        } else {
-            info!("🐙🏷 Added label {label} to PR {id}");
-            ActionResult::Success
-        }
+        ActionResult::from_result(
+            res,
+            || info!("🐙🏷 Added label {label} to PR {id}"),
+            |e| warn!("🐙🏷 Failed to add label to PR {id}: {e}"),
+        )
     }
 
     async fn remove_label_from_pr(
@@ -267,11 +264,10 @@ impl GithubActionExecutor {
                 Err(e) => Err(e),
             }
         };
-        if let Err(e) = res {
-            warn!("🐙🤺 Merge conflict status update failed on PR: {id}. {e}");
-            ActionResult::Failed
-        } else {
-            ActionResult::Success
-        }
+        ActionResult::from_result(
+            res,
+            || debug!("🐙🤺 Merge conflict status check complete for PR {id}"),
+            |e| warn!("🐙🤺 Failed to check merge conflict status for PR {id}: {e}"),
+        )
     }
 }

--- a/server/src/actions/merge_action/message.rs
+++ b/server/src/actions/merge_action/message.rs
@@ -1,7 +1,7 @@
 use actix::Message;
 use github_pilot_api::GithubEvent;
 
-use crate::actions::merge_action::action_params::MergeActionParams;
+use crate::{actions::merge_action::action_params::MergeActionParams, pub_sub::ActionResult};
 
 #[derive(Clone)]
 pub struct MergeActionMessage {
@@ -39,5 +39,5 @@ impl MergeActionMessage {
 }
 
 impl Message for MergeActionMessage {
-    type Result = ();
+    type Result = ActionResult;
 }

--- a/server/src/pub_sub/action_result.rs
+++ b/server/src/pub_sub/action_result.rs
@@ -1,0 +1,28 @@
+use std::error::Error;
+
+pub enum ActionResult {
+    Success,
+    ConditionsNotMet,
+    Failed,
+    Indeterminate,
+}
+
+impl ActionResult {
+    pub fn from_result<T, E, F1, F2>(result: Result<T, E>, on_success: F1, on_failure: F2) -> Self
+    where
+        E: Error,
+        F1: FnOnce(),
+        F2: FnOnce(E),
+    {
+        match result {
+            Ok(_) => {
+                on_success();
+                ActionResult::Success
+            },
+            Err(e) => {
+                on_failure(e);
+                ActionResult::Failed
+            },
+        }
+    }
+}

--- a/server/src/pub_sub/messages.rs
+++ b/server/src/pub_sub/messages.rs
@@ -1,7 +1,7 @@
 use actix::Message;
 use github_pilot_api::GithubEvent;
 
-use crate::{pub_sub::PubSubError, rules::Rule};
+use crate::rules::Rule;
 
 #[derive(Debug, Clone)]
 pub struct GithubEventMessage {
@@ -39,7 +39,7 @@ pub struct ReplaceRulesMessage {
 }
 
 impl Message for ReplaceRulesMessage {
-    type Result = Result<usize, PubSubError>;
+    type Result = usize;
 }
 
 pub struct AddRuleMessage {
@@ -47,5 +47,5 @@ pub struct AddRuleMessage {
 }
 
 impl Message for AddRuleMessage {
-    type Result = Result<usize, PubSubError>;
+    type Result = usize;
 }

--- a/server/src/pub_sub/mod.rs
+++ b/server/src/pub_sub/mod.rs
@@ -1,7 +1,9 @@
+mod action_result;
 mod actor;
 mod error;
 mod messages;
 
+pub use action_result::ActionResult;
 pub use actor::PubSubActor;
 pub use error::PubSubError;
 pub use messages::{AddRuleMessage, GithubEventMessage, ReplaceRulesMessage};


### PR DESCRIPTION
Actions can now return an ActionResult, which is currently one of
*    Success,
* ConditionsNotMet,
* Failed,
* Indeterminate,

The idea being that rules can then respond accordingly with different actions based on whether the base action passed, failed, etc.

Making this a reality meant switching the PubSubActor messages to return FutureResonse types, and switching up the internals on PubSubActor a bit to make everything async-aware.