### PR TITLE
feat: add shorthand pr/issue id cli argument

### DIFF
--- a/cli/src/cli_def.rs
+++ b/cli/src/cli_def.rs
@@ -8,10 +8,10 @@ use github_pilot_api::models_plus::{MergeMethod, MergeParameters};
 pub struct Cli {
     #[clap(subcommand)]
     pub command: Commands,
-    /// The organisation or repository owner (default: tari-project)
+    /// The organisation or repository owner (default: tari-project). Overridden by --id.
     #[clap(short, long, default_value = "tari-project")]
     pub owner: String,
-    /// The repository to query (default: tari)
+    /// The repository to query (default: tari). Overridden by --id.
     #[clap(short, long, default_value = "tari")]
     pub repo: String,
     #[clap(short = 'u', long = "user", env = "GH_PILOT_USERNAME")]
@@ -31,14 +31,22 @@ pub enum Commands {
     /// Fetches a pull request
     PullRequest {
         #[clap(short, long)]
-        number: u64,
+        number: Option<u64>,
+        /// The PR or Issue id to query. Overrides --owner, --repo and --number.
+        /// Must be a string of the form {org}/{repo}#{number}.
+        #[clap(short, long)]
+        id: Option<String>,
         #[clap(subcommand)]
         sub_command: PullRequestCommand,
     },
     /// Query or manipulate an issue
     Issue {
         #[clap(short, long)]
-        number: u64,
+        number: Option<u64>,
+        /// The PR or Issue id to query. Overrides --owner, --repo and --number.
+        /// Must be a string of the form {org}/{repo}#{number}.
+        #[clap(short, long)]
+        id: Option<String>,
         #[clap(subcommand)]
         sub_command: IssueCommand,
     },

--- a/cli/src/issue.rs
+++ b/cli/src/issue.rs
@@ -6,14 +6,7 @@ use crate::{
     pretty_print::{add_labels, pretty_table},
 };
 
-pub async fn run_issue_cmd(
-    provider: &dyn IssueProvider,
-    owner: &str,
-    repo: &str,
-    number: u64,
-    cmd: IssueCommand,
-) -> Result<(), ()> {
-    let id = IssueId::new(owner, repo, number);
+pub async fn run_issue_cmd(provider: &dyn IssueProvider, id: IssueId, cmd: IssueCommand) -> Result<(), ()> {
     match cmd {
         IssueCommand::Fetch => match provider.fetch_issue(&id).await {
             Ok(issue) => pretty_print(issue),

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -8,7 +8,7 @@ mod user;
 
 use clap::Parser;
 use cli_def::{Cli, Commands};
-use github_pilot_api::GithubProvider;
+use github_pilot_api::{wrappers::IssueId, GithubProvider};
 use log::*;
 
 use crate::{
@@ -28,10 +28,40 @@ async fn main() -> Result<(), ()> {
     let repo = cli.repo.as_str();
     match cli.command {
         Commands::User { profile } => run_user_cmd(&provider, &profile).await,
-        Commands::PullRequest { number, sub_command } => run_pr_cmd(&provider, owner, repo, number, sub_command).await,
-        Commands::Issue { number, sub_command } => run_issue_cmd(&provider, owner, repo, number, sub_command).await,
+        Commands::PullRequest {
+            number,
+            sub_command,
+            id,
+        } => {
+            let id = resolve_issue_id(owner, repo, number, id)?;
+            run_pr_cmd(&provider, id, sub_command).await
+        },
+        Commands::Issue {
+            number,
+            sub_command,
+            id,
+        } => {
+            let id = resolve_issue_id(owner, repo, number, id)?;
+            run_issue_cmd(&provider, id, sub_command).await
+        },
         Commands::Labels { sub_command } => run_label_cmd(&provider, owner, repo, sub_command).await,
         Commands::Contributors => run_contributor_cmd(&provider, owner, repo).await,
+    }
+}
+
+fn resolve_issue_id(owner: &str, repo: &str, number: Option<u64>, id_str: Option<String>) -> Result<IssueId, ()> {
+    if let Some(id_str) = id_str {
+        let id = id_str.parse::<IssueId>().map_err(|e| {
+            error!("Invalid issue id \"{id_str}\": {e}");
+        })?;
+        Ok(id)
+    } else {
+        if number.is_none() {
+            error!("You must specify specify either --number or --id");
+            return Err(());
+        }
+        let number = number.unwrap();
+        Ok(IssueId::new(owner, repo, number))
     }
 }
 

--- a/cli/src/pull_request.rs
+++ b/cli/src/pull_request.rs
@@ -18,14 +18,7 @@ use crate::{
     pretty_print::{add_labels, pretty_table},
 };
 
-pub async fn run_pr_cmd(
-    provider: &GithubProvider,
-    owner: &str,
-    repo: &str,
-    number: u64,
-    cmd: PullRequestCommand,
-) -> Result<(), ()> {
-    let id = IssueId::new(owner, repo, number);
+pub async fn run_pr_cmd(provider: &GithubProvider, id: IssueId, cmd: PullRequestCommand) -> Result<(), ()> {
     match cmd {
         PullRequestCommand::Fetch => fetch_pr(provider, id).await,
         PullRequestCommand::AddLabel(l) => match provider.add_label(&id, l.label.as_str()).await {


### PR DESCRIPTION
Provide the `--id` argument for issue and pull-request queries, allowing you to easily override the owner/repo arg in the form `{owner}/{repo}#{number}`

A little quality of life improvement