### PR TITLE
feat: add "then" actions

### DIFF
--- a/server/src/pub_sub/actor.rs
+++ b/server/src/pub_sub/actor.rs
@@ -19,7 +19,7 @@ use crate::{
         MergeExecutor,
     },
     pub_sub::{ActionResult, GithubEventMessage, PubSubError, ReplaceRulesMessage},
-    rules::Rule,
+    rules::{ActionVec, Rule},
     utilities::timestamp,
 };
 
@@ -97,6 +97,88 @@ impl PubSubActor {
             .await
             .map_err(|e| PubSubError::DispatchError(format!("Could not dispatch Github Action message. {}", e)))
     }
+
+    /// Runs all the "Execute" actions attached to this rule. If any action returns `Failed`, `ConditionsNotMet` or
+    /// `Indeterminate`, the overall Result is same and the remaining actions are not run.
+    ///
+    /// Only if all actions return `Success`, will the overall result be `Success`.
+    async fn run_execute_actions(event_name: String, event: GithubEvent, rule: &Rule) -> ActionResult {
+        let name = format!("{}-{}.execute.{}", rule.name(), event_name, timestamp());
+        Self::run_actions(name, event_name, event, rule.actions()).await
+    }
+
+    /// Runs all the "then" actions attached to this rule. If any action returns `Failed`, `ConditionsNotMet` or
+    /// `Indeterminate`,
+    /// the overall Result is same and the remaining actions are not run.
+    ///
+    /// Only if all actions return `Success`, will the overall result be `Success`.
+    async fn run_then_actions(event_name: String, event: GithubEvent, rule: &Rule) -> ActionResult {
+        let name = format!("{}-{}.then.{}", rule.name(), event_name, timestamp());
+        Self::run_actions(name, event_name, event, rule.then_actions()).await
+    }
+
+    /// Runs all the actions attached to this rule. If any action returns `Failed`, `ConditionsNotMet` or
+    /// `Indeterminate`, the overall Result is same and the remaining actions are not run.
+    ///
+    /// Only if all actions return `Success`, will the overall result be `Success`.
+    async fn run_actions(task: String, event_name: String, event: GithubEvent, actions: ActionVec<'_>) -> ActionResult {
+        for action in actions.cloned() {
+            trace!("📰 Dispatching task \"{task}\" on \"{event_name}\"");
+            match Self::dispatch_message(action, event_name.clone(), event.clone()).await {
+                Ok(ActionResult::Success) => {
+                    debug!("📰 Task \"{task}\" on \"{event_name}\" completed successfully")
+                },
+                Ok(ActionResult::ConditionsNotMet) => {
+                    debug!("📰 Task \"{task}\" on \"{event_name}\" was not executed because conditions were not met");
+                    return ActionResult::ConditionsNotMet;
+                },
+                Ok(ActionResult::Failed) => {
+                    debug!("📰 Task \"{task}\" on \"{event_name}\" failed");
+                    return ActionResult::Failed;
+                },
+                Ok(ActionResult::Indeterminate) => {
+                    debug!("📰 Task \"{task}\" on \"{event_name}\" was indeterminate");
+                    return ActionResult::Indeterminate;
+                },
+                Err(e) => {
+                    warn!("📰 There was an issue dispatching {task}: {e}");
+                    return ActionResult::Failed;
+                },
+            }
+        }
+        debug!("📰 All actions for Task \"{task}\" on \"{event_name}\" completed successfully");
+        ActionResult::Success
+    }
+
+    async fn broadcast_result(_result: ActionResult, _event: GithubEvent) {
+        // TODO
+        // create a new InternalEventMessage
+        // send the message to the InternalEventActor
+        // Log the result
+    }
+
+    // note: this private fn cannot call `self` because it is called from an async task.
+    async fn evaluate_rules_against_message(msg: GithubEventMessage, rules: Arc<RwLock<Vec<Rule>>>) {
+        trace!("📰 PubSub received github event message: {}", msg.name());
+        let rules = rules.read().await;
+        let mut rules_matched = 0usize;
+        let (event_name, event) = msg.clone().to_parts();
+        for rule in rules.iter() {
+            // Check if any of the predicates match
+            let rule_triggered = rule.matches(&msg);
+            // If so, dispatch a tasks to run the actions
+            if rule_triggered.is_some() {
+                rules_matched += 1;
+                info!("📰 Rule \"{}\" triggered for \"{}\".", rule.name(), msg.name());
+                let result = Self::run_execute_actions(event_name.clone(), event.clone(), rule).await;
+                if matches!(result, ActionResult::Success) {
+                    let _ = Self::run_then_actions(event_name.clone(), event.clone(), rule).await;
+                }
+                Self::broadcast_result(result, event.clone()).await;
+            }
+        }
+        debug!("📰 {rules_matched} rules matched event \"{event_name}\"");
+    }
 }
 
 impl Actor for PubSubActor {
@@ -122,28 +204,7 @@ impl Handler<GithubEventMessage> for PubSubActor {
     fn handle(&mut self, msg: GithubEventMessage, _ctx: &mut Self::Context) -> Self::Result {
         let copy_of_rules = self.rules.clone();
         let fut = async move {
-            trace!("📰 PubSub received github event message: {}", msg.name());
-            let rules = copy_of_rules.read().await;
-            let mut rules_matched = 0usize;
-            let (event_name, event) = msg.clone().to_parts();
-            for rule in rules.iter() {
-                // Check if any of the predicates match
-                let rule_triggered = rule.matches(&msg);
-                // If so, dispatch a tasks to run the actions
-                if rule_triggered.is_some() {
-                    rules_matched += 1;
-                    info!("📰 Rule \"{}\" triggered for \"{}\".", rule.name(), msg.name());
-                    let name = format!("{}-{}.{}", rule.name(), event_name, timestamp());
-                    for action in rule.actions().cloned() {
-                        trace!("📰 Preparing task \"{name}\"");
-                        let dispatch_result = Self::dispatch_message(action, event_name.clone(), event.clone()).await;
-                        if let Err(e) = dispatch_result {
-                            warn!("📰 There was an issue dispatching {name}: {e}");
-                        }
-                    }
-                }
-            }
-            debug!("📰 {rules_matched} rules matched event \"{event_name}\"");
+            Self::evaluate_rules_against_message(msg, copy_of_rules).await;
         };
         Box::pin(fut)
     }


### PR DESCRIPTION
Adds support for a set of actions to be run if and only if, all the "execute" actions return successfully.

These actions are submitted when building rules:

```
RuleBuilder::new("(AutoLabel) Pull request complexity")
    .when(PullRequest::more_complex_than(PullRequestComplexity::High))
    .execute(Actions::github().add_label("CR-one_job").build())
    .then(Actions::email().sender())
    .submit(),
```