### PR TITLE
fix: handle status checks better

### DIFF
--- a/cli/src/pull_request.rs
+++ b/cli/src/pull_request.rs
@@ -141,15 +141,8 @@ fn print_run_status(summary: &CheckRunStatus) {
     for run in summary.checks() {
         let completed_at = run.completed_at.to_string();
         let result = serde_json::to_string(&run.result).unwrap();
-        let status = serde_json::to_string(&run.status).unwrap();
         let req = run.is_required.to_string();
-        table.add_row([
-            run.name.as_str(),
-            completed_at.as_str(),
-            result.as_str(),
-            status.as_str(),
-            req.as_str(),
-        ]);
+        table.add_row([run.name.as_str(), completed_at.as_str(), result.as_str(), req.as_str()]);
     }
     println!("{table}");
 }

--- a/github-api/src/graphql/check_run_status.rs
+++ b/github-api/src/graphql/check_run_status.rs
@@ -1,0 +1,240 @@
+#![allow(clippy::all, warnings)]
+pub struct CheckRunStatusQL;
+pub mod check_run_status_ql {
+    #![allow(dead_code)]
+    use std::result::Result;
+    pub const OPERATION_NAME: &str = "CheckRunStatusQL";
+    pub const QUERY : & str = "query CheckRunStatusQL($owner: String!, $repo: String!, $pr_number: Int!) {\n    repository(owner: $owner, name:$repo) {\n        pullRequest(number:$pr_number) {\n            commits(last: 1) {\n                nodes {\n                    commit {\n                        url\n                        committedDate\n                        statusCheckRollup {\n                            state\n                        }\n                        checkSuites(last: 10) {\n                            totalCount\n                            nodes {\n                                app {\n                                    name\n                                }\n                                checkRuns(last: 10) {\n                                    totalCount\n                                    nodes {\n                                        completedAt\n                                        conclusion\n                                        isRequired(pullRequestNumber: $pr_number)\n                                        name\n                                        status\n                                    }\n                                }\n                            }\n                        }\n                        status {\n                            contexts {\n                                context\n                                createdAt\n                                isRequired(pullRequestNumber: $pr_number)\n                                state\n                                description\n                            }\n                        }\n                    }\n                }\n            }\n        }\n    }\n}" ;
+    use serde::{Deserialize, Serialize};
+
+    use super::*;
+    #[allow(dead_code)]
+    type Boolean = bool;
+    #[allow(dead_code)]
+    type Float = f64;
+    #[allow(dead_code)]
+    type Int = i64;
+    #[allow(dead_code)]
+    type ID = String;
+    type URI = super::URI;
+    type DateTime = super::DateTime;
+    #[derive()]
+    pub enum CheckStatusState {
+        COMPLETED,
+        IN_PROGRESS,
+        PENDING,
+        QUEUED,
+        REQUESTED,
+        WAITING,
+        Other(String),
+    }
+    impl ::serde::Serialize for CheckStatusState {
+        fn serialize<S: serde::Serializer>(&self, ser: S) -> Result<S::Ok, S::Error> {
+            ser.serialize_str(match *self {
+                CheckStatusState::COMPLETED => "COMPLETED",
+                CheckStatusState::IN_PROGRESS => "IN_PROGRESS",
+                CheckStatusState::PENDING => "PENDING",
+                CheckStatusState::QUEUED => "QUEUED",
+                CheckStatusState::REQUESTED => "REQUESTED",
+                CheckStatusState::WAITING => "WAITING",
+                CheckStatusState::Other(ref s) => &s,
+            })
+        }
+    }
+    impl<'de> ::serde::Deserialize<'de> for CheckStatusState {
+        fn deserialize<D: ::serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+            let s: String = ::serde::Deserialize::deserialize(deserializer)?;
+            match s.as_str() {
+                "COMPLETED" => Ok(CheckStatusState::COMPLETED),
+                "IN_PROGRESS" => Ok(CheckStatusState::IN_PROGRESS),
+                "PENDING" => Ok(CheckStatusState::PENDING),
+                "QUEUED" => Ok(CheckStatusState::QUEUED),
+                "REQUESTED" => Ok(CheckStatusState::REQUESTED),
+                "WAITING" => Ok(CheckStatusState::WAITING),
+                _ => Ok(CheckStatusState::Other(s)),
+            }
+        }
+    }
+    #[derive()]
+    pub enum CheckConclusionState {
+        ACTION_REQUIRED,
+        CANCELLED,
+        FAILURE,
+        NEUTRAL,
+        SKIPPED,
+        STALE,
+        STARTUP_FAILURE,
+        SUCCESS,
+        TIMED_OUT,
+        Other(String),
+    }
+    impl ::serde::Serialize for CheckConclusionState {
+        fn serialize<S: serde::Serializer>(&self, ser: S) -> Result<S::Ok, S::Error> {
+            ser.serialize_str(match *self {
+                CheckConclusionState::ACTION_REQUIRED => "ACTION_REQUIRED",
+                CheckConclusionState::CANCELLED => "CANCELLED",
+                CheckConclusionState::FAILURE => "FAILURE",
+                CheckConclusionState::NEUTRAL => "NEUTRAL",
+                CheckConclusionState::SKIPPED => "SKIPPED",
+                CheckConclusionState::STALE => "STALE",
+                CheckConclusionState::STARTUP_FAILURE => "STARTUP_FAILURE",
+                CheckConclusionState::SUCCESS => "SUCCESS",
+                CheckConclusionState::TIMED_OUT => "TIMED_OUT",
+                CheckConclusionState::Other(ref s) => &s,
+            })
+        }
+    }
+    impl<'de> ::serde::Deserialize<'de> for CheckConclusionState {
+        fn deserialize<D: ::serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+            let s: String = ::serde::Deserialize::deserialize(deserializer)?;
+            match s.as_str() {
+                "ACTION_REQUIRED" => Ok(CheckConclusionState::ACTION_REQUIRED),
+                "CANCELLED" => Ok(CheckConclusionState::CANCELLED),
+                "FAILURE" => Ok(CheckConclusionState::FAILURE),
+                "NEUTRAL" => Ok(CheckConclusionState::NEUTRAL),
+                "SKIPPED" => Ok(CheckConclusionState::SKIPPED),
+                "STALE" => Ok(CheckConclusionState::STALE),
+                "STARTUP_FAILURE" => Ok(CheckConclusionState::STARTUP_FAILURE),
+                "SUCCESS" => Ok(CheckConclusionState::SUCCESS),
+                "TIMED_OUT" => Ok(CheckConclusionState::TIMED_OUT),
+                _ => Ok(CheckConclusionState::Other(s)),
+            }
+        }
+    }
+    #[derive()]
+    pub enum StatusState {
+        ERROR,
+        EXPECTED,
+        FAILURE,
+        PENDING,
+        SUCCESS,
+        Other(String),
+    }
+    impl ::serde::Serialize for StatusState {
+        fn serialize<S: serde::Serializer>(&self, ser: S) -> Result<S::Ok, S::Error> {
+            ser.serialize_str(match *self {
+                StatusState::ERROR => "ERROR",
+                StatusState::EXPECTED => "EXPECTED",
+                StatusState::FAILURE => "FAILURE",
+                StatusState::PENDING => "PENDING",
+                StatusState::SUCCESS => "SUCCESS",
+                StatusState::Other(ref s) => &s,
+            })
+        }
+    }
+    impl<'de> ::serde::Deserialize<'de> for StatusState {
+        fn deserialize<D: ::serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+            let s: String = ::serde::Deserialize::deserialize(deserializer)?;
+            match s.as_str() {
+                "ERROR" => Ok(StatusState::ERROR),
+                "EXPECTED" => Ok(StatusState::EXPECTED),
+                "FAILURE" => Ok(StatusState::FAILURE),
+                "PENDING" => Ok(StatusState::PENDING),
+                "SUCCESS" => Ok(StatusState::SUCCESS),
+                _ => Ok(StatusState::Other(s)),
+            }
+        }
+    }
+    #[derive(Serialize)]
+    pub struct Variables {
+        pub owner: String,
+        pub repo: String,
+        pub pr_number: Int,
+    }
+    impl Variables {}
+    #[derive(Deserialize)]
+    pub struct ResponseData {
+        pub repository: Option<CheckRunStatusQlRepository>,
+    }
+    #[derive(Deserialize)]
+    pub struct CheckRunStatusQlRepository {
+        #[serde(rename = "pullRequest")]
+        pub pull_request: Option<CheckRunStatusQlRepositoryPullRequest>,
+    }
+    #[derive(Deserialize)]
+    pub struct CheckRunStatusQlRepositoryPullRequest {
+        pub commits: CheckRunStatusQlRepositoryPullRequestCommits,
+    }
+    #[derive(Deserialize)]
+    pub struct CheckRunStatusQlRepositoryPullRequestCommits {
+        pub nodes: Option<Vec<Option<CheckRunStatusQlRepositoryPullRequestCommitsNodes>>>,
+    }
+    #[derive(Deserialize)]
+    pub struct CheckRunStatusQlRepositoryPullRequestCommitsNodes {
+        pub commit: CheckRunStatusQlRepositoryPullRequestCommitsNodesCommit,
+    }
+    #[derive(Deserialize)]
+    pub struct CheckRunStatusQlRepositoryPullRequestCommitsNodesCommit {
+        pub url: URI,
+        #[serde(rename = "committedDate")]
+        pub committed_date: DateTime,
+        #[serde(rename = "statusCheckRollup")]
+        pub status_check_rollup: Option<CheckRunStatusQlRepositoryPullRequestCommitsNodesCommitStatusCheckRollup>,
+        #[serde(rename = "checkSuites")]
+        pub check_suites: Option<CheckRunStatusQlRepositoryPullRequestCommitsNodesCommitCheckSuites>,
+        pub status: Option<CheckRunStatusQlRepositoryPullRequestCommitsNodesCommitStatus>,
+    }
+    #[derive(Deserialize)]
+    pub struct CheckRunStatusQlRepositoryPullRequestCommitsNodesCommitStatusCheckRollup {
+        pub state: StatusState,
+    }
+    #[derive(Deserialize)]
+    pub struct CheckRunStatusQlRepositoryPullRequestCommitsNodesCommitCheckSuites {
+        #[serde(rename = "totalCount")]
+        pub total_count: Int,
+        pub nodes: Option<Vec<Option<CheckRunStatusQlRepositoryPullRequestCommitsNodesCommitCheckSuitesNodes>>>,
+    }
+    #[derive(Deserialize)]
+    pub struct CheckRunStatusQlRepositoryPullRequestCommitsNodesCommitCheckSuitesNodes {
+        pub app: Option<CheckRunStatusQlRepositoryPullRequestCommitsNodesCommitCheckSuitesNodesApp>,
+        #[serde(rename = "checkRuns")]
+        pub check_runs: Option<CheckRunStatusQlRepositoryPullRequestCommitsNodesCommitCheckSuitesNodesCheckRuns>,
+    }
+    #[derive(Deserialize)]
+    pub struct CheckRunStatusQlRepositoryPullRequestCommitsNodesCommitCheckSuitesNodesApp {
+        pub name: String,
+    }
+    #[derive(Deserialize)]
+    pub struct CheckRunStatusQlRepositoryPullRequestCommitsNodesCommitCheckSuitesNodesCheckRuns {
+        #[serde(rename = "totalCount")]
+        pub total_count: Int,
+        pub nodes:
+            Option<Vec<Option<CheckRunStatusQlRepositoryPullRequestCommitsNodesCommitCheckSuitesNodesCheckRunsNodes>>>,
+    }
+    #[derive(Deserialize)]
+    pub struct CheckRunStatusQlRepositoryPullRequestCommitsNodesCommitCheckSuitesNodesCheckRunsNodes {
+        #[serde(rename = "completedAt")]
+        pub completed_at: Option<DateTime>,
+        pub conclusion: Option<CheckConclusionState>,
+        #[serde(rename = "isRequired")]
+        pub is_required: Boolean,
+        pub name: String,
+        pub status: CheckStatusState,
+    }
+    #[derive(Deserialize)]
+    pub struct CheckRunStatusQlRepositoryPullRequestCommitsNodesCommitStatus {
+        pub contexts: Vec<CheckRunStatusQlRepositoryPullRequestCommitsNodesCommitStatusContexts>,
+    }
+    #[derive(Deserialize)]
+    pub struct CheckRunStatusQlRepositoryPullRequestCommitsNodesCommitStatusContexts {
+        pub context: String,
+        #[serde(rename = "createdAt")]
+        pub created_at: DateTime,
+        #[serde(rename = "isRequired")]
+        pub is_required: Boolean,
+        pub state: StatusState,
+        pub description: Option<String>,
+    }
+}
+impl graphql_client::GraphQLQuery for CheckRunStatusQL {
+    type ResponseData = check_run_status_ql::ResponseData;
+    type Variables = check_run_status_ql::Variables;
+
+    fn build_query(variables: Self::Variables) -> ::graphql_client::QueryBody<Self::Variables> {
+        graphql_client::QueryBody {
+            variables,
+            query: check_run_status_ql::QUERY,
+            operation_name: check_run_status_ql::OPERATION_NAME,
+        }
+    }
+}

--- a/github-api/src/graphql/data/check_run_status.graphql
+++ b/github-api/src/graphql/data/check_run_status.graphql
@@ -27,6 +27,15 @@ query CheckRunStatusQL($owner: String!, $repo: String!, $pr_number: Int!) {
                                 }
                             }
                         }
+                        status {
+                            contexts {
+                                context
+                                createdAt
+                                isRequired(pullRequestNumber: $pr_number)
+                                state
+                                description
+                            }
+                        }
                     }
                 }
             }

--- a/github-api/src/graphql/data/sample_check_run.json
+++ b/github-api/src/graphql/data/sample_check_run.json
@@ -5,10 +5,10 @@
           "nodes": [
             {
               "commit": {
-                "url": "https://github.com/tari-project/gh-pilot/commit/c13501c51f6a3f5183f5921aa89d68110a29f0f4",
-                "committedDate": "2022-09-20T15:30:05Z",
+                "url": "https://github.com/tari-project/tari/commit/eebba41dd22dbcc8ce94b86a0c25cf8d483dc3d7",
+                "committedDate": "2022-10-18T11:36:33Z",
                 "statusCheckRollup": {
-                  "state": "SUCCESS"
+                  "state": "FAILURE"
                 },
                 "checkSuites": {
                   "totalCount": 4,
@@ -21,27 +21,9 @@
                         "totalCount": 1,
                         "nodes": [
                           {
-                            "completedAt": "2022-09-20T15:35:54Z",
+                            "completedAt": "2022-10-18T11:39:59Z",
                             "conclusion": "SUCCESS",
-                            "isRequired": false,
-                            "name": "clippy_check",
-                            "status": "COMPLETED",
-                            "summary": null
-                          }
-                        ]
-                      }
-                    },
-                    {
-                      "app": {
-                        "name": "GitHub Actions"
-                      },
-                      "checkRuns": {
-                        "totalCount": 1,
-                        "nodes": [
-                          {
-                            "completedAt": "2022-09-20T15:32:28Z",
-                            "conclusion": "SUCCESS",
-                            "isRequired": false,
+                            "isRequired": true,
                             "name": "check-title",
                             "status": "COMPLETED",
                             "summary": null
@@ -54,21 +36,53 @@
                         "name": "GitHub Actions"
                       },
                       "checkRuns": {
-                        "totalCount": 2,
+                        "totalCount": 6,
                         "nodes": [
                           {
-                            "completedAt": "2022-09-20T15:42:12Z",
+                            "completedAt": "2022-10-18T11:45:31Z",
                             "conclusion": "SUCCESS",
                             "isRequired": false,
-                            "name": "cargo test (stable)",
+                            "name": "check nightly",
                             "status": "COMPLETED",
                             "summary": null
                           },
                           {
-                            "completedAt": "2022-09-20T15:40:49Z",
+                            "completedAt": "2022-10-18T11:39:55Z",
                             "conclusion": "SUCCESS",
                             "isRequired": false,
-                            "name": "cargo test (nightly-2022-09-13)",
+                            "name": "pr_2_artifact",
+                            "status": "COMPLETED",
+                            "summary": null
+                          },
+                          {
+                            "completedAt": "2022-10-18T11:43:54Z",
+                            "conclusion": "SUCCESS",
+                            "isRequired": false,
+                            "name": "check stable",
+                            "status": "COMPLETED",
+                            "summary": null
+                          },
+                          {
+                            "completedAt": "2022-10-18T11:52:49Z",
+                            "conclusion": "SUCCESS",
+                            "isRequired": true,
+                            "name": "clippy",
+                            "status": "COMPLETED",
+                            "summary": null
+                          },
+                          {
+                            "completedAt": "2022-10-18T11:39:57Z",
+                            "conclusion": "SUCCESS",
+                            "isRequired": false,
+                            "name": "file licenses",
+                            "status": "COMPLETED",
+                            "summary": null
+                          },
+                          {
+                            "completedAt": "2022-10-18T11:52:47Z",
+                            "conclusion": "SUCCESS",
+                            "isRequired": true,
+                            "name": "test",
                             "status": "COMPLETED",
                             "summary": null
                           }
@@ -83,15 +97,58 @@
                         "totalCount": 1,
                         "nodes": [
                           {
-                            "completedAt": "2022-09-20T15:36:07Z",
+                            "completedAt": "2022-10-18T11:41:40Z",
                             "conclusion": "SUCCESS",
-                            "isRequired": false,
+                            "isRequired": true,
                             "name": "check-title",
                             "status": "COMPLETED",
                             "summary": null
                           }
                         ]
                       }
+                    },
+                    {
+                      "app": {
+                        "name": "GitHub Actions"
+                      },
+                      "checkRuns": {
+                        "totalCount": 1,
+                        "nodes": [
+                          {
+                            "completedAt": "2022-10-18T15:22:48Z",
+                            "conclusion": "SUCCESS",
+                            "isRequired": true,
+                            "name": "check-title",
+                            "status": "COMPLETED",
+                            "summary": null
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                },
+                "status": {
+                  "contexts": [
+                    {
+                      "context": "ci/circleci: run-ffi-integration-tests",
+                      "createdAt": "2022-10-18T12:08:03Z",
+                      "isRequired": false,
+                      "state": "FAILURE",
+                      "description": "Your tests failed on CircleCI"
+                    },
+                    {
+                      "context": "ci/circleci: run-integration-tests",
+                      "createdAt": "2022-10-18T12:20:13Z",
+                      "isRequired": false,
+                      "state": "FAILURE",
+                      "description": "Your tests failed on CircleCI"
+                    },
+                    {
+                      "context": "DeepSource: Rust",
+                      "createdAt": "2022-10-18T11:40:20Z",
+                      "isRequired": false,
+                      "state": "SUCCESS",
+                      "description": "Analysis Passed: No blocking issues detected"
                     }
                   ]
                 }

--- a/github-api/src/graphql/mod.rs
+++ b/github-api/src/graphql/mod.rs
@@ -3,4 +3,4 @@ pub mod review_counts;
 pub mod run_status;
 
 pub use pr_comments::{Comment, CommentThread, PullRequestComments};
-pub use run_status::{CheckRunStatus, RunStatus};
+pub use run_status::{CheckResult, CheckRunStatus, RunStatus};

--- a/github-api/src/graphql/run_status.rs
+++ b/github-api/src/graphql/run_status.rs
@@ -1,7 +1,7 @@
-use std::slice::Iter;
+use std::collections::{hash_map::Values, HashMap};
 
 use graphql_client::GraphQLQuery;
-use log::warn;
+use serde::Serialize;
 
 use crate::models::{DateTime, Url};
 
@@ -17,18 +17,27 @@ type URI = Url;
 )]
 pub struct CheckRunStatusQL;
 
+#[derive(Debug, Clone)]
 pub struct CheckRunStatus {
     commit_url: Url,
     committed_at: DateTime,
     overall_status: Option<check_run_status_ql::StatusState>,
-    checks: Vec<RunStatus>,
+    checks: HashMap<String, RunStatus>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub enum CheckResult {
+    ERROR,
+    FAILURE,
+    PENDING,
+    SUCCESS,
+}
+
+#[derive(Debug, Clone)]
 pub struct RunStatus {
     pub name: String,
     pub completed_at: DateTime,
-    pub result: check_run_status_ql::CheckConclusionState,
-    pub status: check_run_status_ql::CheckStatusState,
+    pub result: CheckResult,
     pub is_required: bool,
 }
 
@@ -38,10 +47,15 @@ impl Default for CheckRunStatus {
             commit_url: Url::from(""),
             committed_at: DateTime::default(),
             overall_status: None,
-            checks: vec![],
+            checks: HashMap::new(),
         }
     }
 }
+
+use check_run_status_ql::{
+    CheckRunStatusQlRepositoryPullRequestCommitsNodesCommitCheckSuitesNodesCheckRunsNodes as CheckRunSuite,
+    CheckRunStatusQlRepositoryPullRequestCommitsNodesCommitStatusContexts as StatusContext,
+};
 
 impl CheckRunStatus {
     pub fn commit_url(&self) -> &Url {
@@ -56,8 +70,88 @@ impl CheckRunStatus {
         self.overall_status.as_ref()
     }
 
-    pub fn checks(&self) -> Iter<RunStatus> {
-        self.checks.iter()
+    pub fn checks(&self) -> Values<String, RunStatus> {
+        self.checks.values()
+    }
+
+    pub fn totals(&self) -> (usize, usize, usize) {
+        let (required, passed) = self.checks().fold((0usize, 0usize), |(required, success), check| {
+            if check.is_required {
+                (
+                    required + 1,
+                    success + usize::from(check.result == CheckResult::SUCCESS),
+                )
+            } else {
+                (required, success)
+            }
+        });
+        (self.checks.len(), required, passed)
+    }
+
+    pub fn has_passed(&self) -> bool {
+        if matches!(self.overall_status, Some(check_run_status_ql::StatusState::SUCCESS)) {
+            return true;
+        }
+        self.checks
+            .values()
+            .filter(|&check| check.is_required)
+            .all(|check| matches!(check.result, CheckResult::SUCCESS))
+    }
+}
+
+impl From<check_run_status_ql::StatusState> for CheckResult {
+    fn from(state: check_run_status_ql::StatusState) -> Self {
+        match state {
+            check_run_status_ql::StatusState::FAILURE => CheckResult::FAILURE,
+            check_run_status_ql::StatusState::PENDING => CheckResult::PENDING,
+            check_run_status_ql::StatusState::EXPECTED => CheckResult::PENDING,
+            check_run_status_ql::StatusState::SUCCESS => CheckResult::SUCCESS,
+            check_run_status_ql::StatusState::ERROR => CheckResult::ERROR,
+            check_run_status_ql::StatusState::Other(_) => CheckResult::ERROR,
+        }
+    }
+}
+
+impl From<check_run_status_ql::CheckConclusionState> for CheckResult {
+    fn from(state: check_run_status_ql::CheckConclusionState) -> Self {
+        match state {
+            check_run_status_ql::CheckConclusionState::ACTION_REQUIRED => CheckResult::FAILURE,
+            check_run_status_ql::CheckConclusionState::CANCELLED => CheckResult::ERROR,
+            check_run_status_ql::CheckConclusionState::FAILURE => CheckResult::FAILURE,
+            check_run_status_ql::CheckConclusionState::NEUTRAL => CheckResult::FAILURE,
+            check_run_status_ql::CheckConclusionState::SKIPPED => CheckResult::ERROR,
+            check_run_status_ql::CheckConclusionState::STALE => CheckResult::ERROR,
+            check_run_status_ql::CheckConclusionState::STARTUP_FAILURE => CheckResult::ERROR,
+            check_run_status_ql::CheckConclusionState::SUCCESS => CheckResult::SUCCESS,
+            check_run_status_ql::CheckConclusionState::TIMED_OUT => CheckResult::ERROR,
+            check_run_status_ql::CheckConclusionState::Other(_) => CheckResult::ERROR,
+        }
+    }
+}
+
+impl From<CheckRunSuite> for RunStatus {
+    fn from(suite: CheckRunSuite) -> Self {
+        Self {
+            name: suite.name,
+            completed_at: suite.completed_at.unwrap_or_default(),
+            result: CheckResult::from(
+                suite
+                    .conclusion
+                    .unwrap_or(check_run_status_ql::CheckConclusionState::SKIPPED),
+            ),
+            is_required: suite.is_required,
+        }
+    }
+}
+
+impl From<StatusContext> for RunStatus {
+    fn from(s: StatusContext) -> Self {
+        Self {
+            name: s.context,
+            completed_at: s.created_at,
+            result: CheckResult::from(s.state),
+            is_required: s.is_required,
+        }
     }
 }
 
@@ -84,62 +178,40 @@ impl From<check_run_status_ql::ResponseData> for CheckRunStatus {
             committed_date: committed_at,
             status_check_rollup,
             check_suites,
+            status,
         } = match statuses.into_iter().next() {
             Some(Some(CN { commit: c })) => c,
             _ => return CheckRunStatus::default(),
         };
-        let overall_status = status_check_rollup.map(|s| s.state);
-        let checks = match check_suites {
-            Some(cs) => cs
-                .nodes
-                .into_iter()
-                .flatten()
-                .flatten()
-                .flat_map(|node| {
-                    let app_name = node
-                        .app
-                        .map(|app| app.name)
-                        .unwrap_or_else(|| "App name not provided".to_string());
-                    match node.check_runs {
-                        Some(cr) => {
-                            let run_count = cr.total_count as usize;
-                            let fetched = cr.nodes.iter().flatten().flatten().count();
-                            if run_count != fetched {
-                                warn!(
-                                    "There are {run_count} check runs for {app_name}, but only {fetched} were \
-                                     fetched. File a bug report saying we need proper pagination in the run_status \
-                                     query code."
-                                );
-                            }
-                            cr.nodes
-                                .into_iter()
-                                .flatten()
-                                .flatten()
-                                .map(|run| {
-                                    let name = run.name;
-                                    let completed_at = run.completed_at.unwrap_or_default();
-                                    let result = run.conclusion.unwrap_or_else(|| {
-                                        check_run_status_ql::CheckConclusionState::Other("unknown".to_string())
-                                    });
-                                    let status = run.status;
-                                    let is_required = run.is_required;
-                                    RunStatus {
-                                        name,
-                                        completed_at,
-                                        result,
-                                        status,
-                                        is_required,
-                                    }
-                                })
-                                .collect::<Vec<RunStatus>>()
-                        },
-                        None => vec![],
-                    }
-                })
-                .collect(),
-            None => vec![],
-        };
 
+        let overall_status = status_check_rollup.map(|s| s.state);
+        let checks = check_suites
+            .into_iter()
+            .flat_map(|cs| {
+                cs.nodes.into_iter().flatten().flatten().flat_map(|node| {
+                    node.check_runs
+                        .map(|cr| cr.nodes.into_iter().flatten().flatten().map(RunStatus::from))
+                })
+            })
+            .flatten();
+
+        let statuses = status
+            .into_iter()
+            .flat_map(|s| s.contexts.into_iter().map(RunStatus::from));
+
+        let checks = checks
+            .chain(statuses)
+            .fold(HashMap::new(), |mut map: HashMap<String, RunStatus>, status| {
+                let insert = if let Some(existing) = map.get(&status.name) {
+                    status.completed_at > existing.completed_at
+                } else {
+                    true
+                };
+                if insert {
+                    map.insert(status.name.clone(), status);
+                }
+                map
+            });
         CheckRunStatus {
             commit_url,
             committed_at,
@@ -151,36 +223,40 @@ impl From<check_run_status_ql::ResponseData> for CheckRunStatus {
 
 #[cfg(test)]
 mod test {
-    use super::check_run_status_ql::{CheckConclusionState, CheckStatusState, ResponseData, StatusState};
-    use crate::graphql::CheckRunStatus;
+    use super::check_run_status_ql::{ResponseData, StatusState};
+    use crate::graphql::{run_status::CheckResult, CheckRunStatus};
 
     #[test]
     fn deserialization() {
         let json = include_str!("data/sample_check_run.json");
         let res: ResponseData = serde_json::from_str(json).unwrap();
         let status = CheckRunStatus::from(res);
-        assert_eq!(status.overall_status, Some(StatusState::SUCCESS));
+        assert_eq!(status.overall_status, Some(StatusState::FAILURE));
         assert_eq!(
             status.commit_url.as_ref(),
-            "https://github.com/tari-project/gh-pilot/commit/c13501c51f6a3f5183f5921aa89d68110a29f0f4"
+            "https://github.com/tari-project/tari/commit/eebba41dd22dbcc8ce94b86a0c25cf8d483dc3d7"
         );
-        assert_eq!(status.committed_at.to_string(), "2022-09-20T15:30:05Z");
-        assert_eq!(status.checks.len(), 5);
-        let check = &status.checks[0];
-        assert_eq!(check.name, "clippy_check");
-        assert_eq!(check.completed_at.to_string(), "2022-09-20T15:35:54Z");
+        assert_eq!(status.committed_at.to_string(), "2022-10-18T11:36:33Z");
+        assert_eq!(status.checks.len(), 10);
+
+        let check = status.checks.get("check-title").unwrap();
+        assert_eq!(check.name, "check-title");
+        assert_eq!(check.completed_at.to_string(), "2022-10-18T15:22:48Z");
+        assert!(check.is_required);
+        assert_eq!(check.result, CheckResult::SUCCESS);
+
+        let check = status.checks.get("check stable").unwrap();
+        assert_eq!(check.name, "check stable");
+        assert_eq!(check.result, CheckResult::SUCCESS);
+
+        let check = status.checks.get("ci/circleci: run-ffi-integration-tests").unwrap();
+        assert_eq!(check.name, "ci/circleci: run-ffi-integration-tests");
+        assert_eq!(check.result, CheckResult::FAILURE);
         assert!(!check.is_required);
-        assert_eq!(check.result, CheckConclusionState::SUCCESS);
-        assert_eq!(check.status, CheckStatusState::COMPLETED);
-        let check = &status.checks[1];
-        assert_eq!(check.name, "check-title");
-        assert_eq!(check.result, CheckConclusionState::SUCCESS);
-        assert_eq!(check.status, CheckStatusState::COMPLETED);
-        let check = &status.checks[2];
-        assert_eq!(check.name, "cargo test (stable)");
-        let check = &status.checks[3];
-        assert_eq!(check.name, "cargo test (nightly-2022-09-13)");
-        let check = &status.checks[4];
-        assert_eq!(check.name, "check-title");
+
+        let check = status.checks.get("DeepSource: Rust").unwrap();
+        assert_eq!(check.name, "DeepSource: Rust");
+        assert_eq!(check.result, CheckResult::SUCCESS);
+        assert!(!check.is_required);
     }
 }

--- a/github-api/src/models/date_time.rs
+++ b/github-api/src/models/date_time.rs
@@ -10,7 +10,7 @@ use serde::{
 
 pub type Timestamp = chrono::DateTime<Utc>;
 
-#[derive(Clone, Debug, Serialize, PartialEq, Eq)]
+#[derive(Clone, Debug, Serialize, PartialEq, Eq, PartialOrd)]
 pub struct DateTime(#[serde(deserialize_with = "to_datetime")] Timestamp);
 
 impl DateTime {


### PR DESCRIPTION
## Issues:
* The status roll up result sometimes returns a false negative External tests (e.g. CircleCI) were not included in the results * Repeated tests were being double-counted.

## Now:
* Update graphQL query to return external tests too
* Only use status rollup if it returns success
* Refactor RunStatus to hold a HashMap of only the latest result of each test
* Coerce GHA and external tests into the same RunStatus struct Provide helper functions in RunStatus to clean up the MergeAction code Tidy up nested `impl From` mess a bit
* Manage to avoid using `collect` when zipping two monstrously nested iterators :)
