### PR TITLE
feat: use current directory git remote

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "ghp-cli"
+name = "ghp"
 version = "0.1.0"
 edition = "2021"
 description = "A command line interface for GitHub Pages; intended as a client partner tool to the Github Pilot server"
@@ -12,9 +12,11 @@ clap = {version = "4.0.29", features = ["derive", "env"] }
 comfy-table = "6.0.0"
 dotenv = "0.15.0"
 env_logger = "0.9.0"
+git2 = "0.15.0"
 hex = "0.4.3"
 log = "0.4.17"
 prompts = { version = "0.4", git = "https://github.com/CjS77/prompts-rs.git", branch = "main"}
 serde_json = "1.0.70"
 serde_yaml = "0.9.13"
 tokio = {version = "1.20.1", features = ["full"] }
+url = "2.3.1"

--- a/cli/src/cli_def.rs
+++ b/cli/src/cli_def.rs
@@ -36,8 +36,8 @@ pub enum Commands {
         profile: Option<String>,
     },
     /// Fetches a pull request
+    #[clap(alias = "pr")]
     PullRequest {
-        #[clap(short, long)]
         number: Option<u64>,
         #[clap(subcommand)]
         sub_command: PullRequestCommand,

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -3,10 +3,12 @@ mod cli_prompts;
 mod pilot_command;
 mod pretty_print;
 
+use std::str::FromStr;
+
 use clap::Parser;
 use cli_def::Cli;
 use dotenv::dotenv;
-use github_pilot_api::GithubProvider;
+use github_pilot_api::{wrappers::RepoId, GithubProvider};
 use log::*;
 
 #[tokio::main]
@@ -14,6 +16,8 @@ async fn main() -> Result<(), String> {
     dotenv().ok();
     env_logger::init();
     let mut cli: Cli = Cli::parse();
+    let _ = try_merge_current_repo_settings(&mut cli)
+        .map_err(|e| debug!("Not using current directory's git settings: {}", e));
     // Use the UI to fill in missing arguments if needed
     let provider = setup_github_api(&cli);
     let cmd = cli.as_pilot_command(&provider).await?;
@@ -39,4 +43,36 @@ fn setup_github_api(cli: &Cli) -> GithubProvider {
             GithubProvider::default()
         },
     }
+}
+
+fn try_merge_current_repo_settings(cli: &mut Cli) -> Result<(), String> {
+    let current_dir_repo =
+        git2::Repository::discover(".").map_err(|e| format!("Current directory is not a git repository:{}", e))?;
+    let remote = current_dir_repo
+        .find_remote("origin")
+        .map_err(|e| format!("Current directory does not have a remote:{}", e))?;
+    let remote_url = remote.url().ok_or_else(|| "Remote does not have a URL".to_string())?;
+    let url = if remote_url.starts_with("http") {
+        url::Url::parse(remote_url)
+            .map_err(|e| format!("Not a valid remote url:{}", e))?
+            .path()
+            .to_string()
+    } else if remote_url.starts_with("git") {
+        let path: Vec<&str> = remote_url.split(':').collect();
+        path.get(1)
+            .ok_or_else(|| "Invalid remote git url".to_string())?
+            .to_string()
+    } else {
+        return Err("Unknown remote url format".to_string());
+    };
+
+    if let Ok(repo_id) = RepoId::from_str(&url) {
+        if cli.repo.is_none() {
+            cli.repo = Some(repo_id.repo);
+        }
+        if cli.owner.is_none() {
+            cli.owner = Some(repo_id.owner);
+        }
+    }
+    Ok(())
 }

--- a/github-api/src/wrappers/repo_id.rs
+++ b/github-api/src/wrappers/repo_id.rs
@@ -44,7 +44,7 @@ pub enum RepoIdParseError {
 impl FromStr for RepoId {
     type Err = RepoIdParseError;
 
-    /// Parses a string of the format `{owner}/{repo}` into a `RepoId`.
+    /// Parses a string of the format `{owner}/{repo}(.git)` into a `RepoId`.
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let mut split = s.split('/');
         let owner = split
@@ -57,6 +57,11 @@ impl FromStr for RepoId {
         if repo.is_empty() {
             return Err(RepoIdParseError::FormatError("Repo cannot be empty".to_string()));
         }
+        let repo = if repo.contains('.') {
+            repo.split('.').next().unwrap()
+        } else {
+            repo
+        };
         Ok(Self {
             owner: owner.to_string(),
             repo: repo.to_string(),


### PR DESCRIPTION
Use the current directory's git settings for the org and remote if it is present.

Some other small fixes, which can be moved to another PR if needed:
1. Renamed ghp-cli to ghp. This helps with typing the command when used a lot
2. Add alias for `pull-request` to `pr`
3. Remove `-n` requirement for `pr -n 4969 fetch`, so it's now `ghp pr 4969 fetch`
4. Strip `.git` from repo_id in `from_str` if it is present