### PR TITLE
feat: load rules from external file

### DIFF
--- a/rules.yaml
+++ b/rules.yaml
@@ -1,0 +1,43 @@
+---
+rules:
+  - name: (AutoLabel) Pull request size
+    when:
+      - pull_request:
+          size_greater_than: medium
+    execute:
+      - github:
+          add_label: CR-too_long
+  - name: (AutoLabel) Pull request complexity
+    when:
+      - pull_request:
+          more_complex_than: high
+    execute:
+      - github:
+          add_label: CR-one_job
+  - name: (AutoLabel) Pull request justification
+    when:
+      - pull_request: poor_justification
+    execute:
+      - github:
+          add_label: CR-insufficient_context
+  - name: Merge conflict check
+    when:
+      - pull_request: opened
+      - pull_request: reopened
+      - pull_request: synchronize
+      - pull_request: edited
+    execute:
+      - github: check_conflicts
+  - name: AutoMerge™
+    when:
+      - pull_request:
+          labeled: P-merge
+      - pull_request: edited
+      - pull_request: approved
+      - pull_request_comment:
+          added: null
+      - status_check: check_suite_success
+    execute:
+      - merge:
+          acks_required: 1
+          perform_merge: true

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -11,18 +11,24 @@ github-pilot-api = { version = "0.1", path = "../github-api" }
 actix = { version = "0.13.0" }
 actix-web = "4.1.0"
 async-trait = "0.1.57"
-env_logger = "0.9.0"
+env_logger = "0.10.0"
 erased-serde = "0.3.23"
 futures = "0.3.21"
 hmac = "0.12.1"
 log = "0.4.17"
 regex = "1.6.0"
-serde = {version = "1.0.142", features = ["derive", "rc"] }
-serde_json = "1.0.83"
-serde_yaml = "0.8"
+serde = { version = "1.0.142", features = ["derive", "rc"] }
+serde_json = { version = "1.0.83", optional = true }
+# Do not upgrade to 0.9+ unless the nested enum issue has been fixed
+serde_yaml = { version = "0.8", optional = true }
 sha2 = "0.10.5"
 subtle = "2.4.1"
 thiserror = "1.0.32"
 tari_utilities = "0.3.0"
 tokio = { version = "1.20.1", features = ["full"] }
 zeroize = "1.5.7"
+
+[features]
+json = ["serde_json"]
+yaml = ["serde_yaml"]
+default = ["json", "yaml"]

--- a/server/src/config.rs
+++ b/server/src/config.rs
@@ -1,6 +1,7 @@
 pub struct ServerConfig {
     pub host: String,
     pub port: u16,
+    pub rule_set_path: String,
 }
 
 impl Default for ServerConfig {
@@ -8,6 +9,7 @@ impl Default for ServerConfig {
         Self {
             host: "127.0.0.1".to_string(),
             port: 8330,
+            rule_set_path: "rules.yaml".into(),
         }
     }
 }
@@ -17,6 +19,7 @@ impl ServerConfig {
         Self {
             host: host.to_string(),
             port,
+            ..Default::default()
         }
     }
 }

--- a/server/src/rule_set.rs
+++ b/server/src/rule_set.rs
@@ -3,6 +3,8 @@
 //!
 //! We maintain a vector of rules because order is important. Rules are run in the order that they are defined.
 
+use std::{io::ErrorKind, path::Path};
+
 use serde::{Deserialize, Serialize};
 
 use crate::rules::Rule;
@@ -13,8 +15,27 @@ pub struct RuleSet {
 }
 
 impl RuleSet {
+    #[cfg(feature = "json")]
+    pub fn from_json<P: AsRef<Path>>(path: P) -> Result<Self, std::io::Error> {
+        let json_file = std::fs::read_to_string(path)?;
+        let rs = serde_json::from_str(json_file.as_str())?;
+        Ok(rs)
+    }
+
+    #[cfg(feature = "yaml")]
+    pub fn from_yaml<P: AsRef<Path>>(path: P) -> Result<Self, std::io::Error> {
+        let yaml_file = std::fs::read_to_string(path)?;
+        let rs =
+            serde_yaml::from_str(yaml_file.as_str()).map_err(|e| std::io::Error::new(ErrorKind::InvalidData, e))?;
+        Ok(rs)
+    }
+
     pub fn add_rule(&mut self, rule: Rule) {
         self.rules.push(rule);
+    }
+
+    pub fn to_rules(self) -> Vec<Rule> {
+        self.rules
     }
 }
 


### PR DESCRIPTION
- Rules are now loaded from rules.yaml
- the base set of rules have been reformatted as YAML (except the ones with closures, which cannot be yaml'd)