### PR TITLE
fix: improve cache naming

### DIFF
--- a/.github/workflows/clippy-check.yml
+++ b/.github/workflows/clippy-check.yml
@@ -22,11 +22,10 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: ${{ runner.os }}-cargo-${{ env.RUST_VERSION }}-clippy-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-${{ env.RUST_VERSION }}-${{ hashFiles('**/Cargo.lock') }}-clippy
           restore-keys: |
             ${{ runner.os }}-cargo-${{ env.RUST_VERSION }}-${{ hashFiles('**/Cargo.lock') }}
             ${{ runner.os }}-cargo-${{ env.RUST_VERSION }}
-            ${{ runner.os }}-cargo-
       - uses: actions-rs/cargo@v1
         with:
           command: fmt

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,11 +29,10 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: ${{ runner.os }}-cargo-${{ env.RUST_VERSION }}-test-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-${{ env.RUST_VERSION }}-${{ hashFiles('**/Cargo.lock') }}-test
           restore-keys: |
             ${{ runner.os }}-cargo-${{ env.RUST_VERSION }}-${{ hashFiles('**/Cargo.lock') }}
-            ${{ runner.os }}-cargo-${{ env.RUST_VERSION }}
-            ${{ runner.os }}-cargo-
+            ${{ runner.os }}-cargo-${{ env.RUST_VERSION }}-
       - name: test/release
         uses: actions-rs/cargo@v1
         with:


### PR DESCRIPTION
Add the GA type to the end of the cache. Simce partial matches are used in `restore-keys` this should make more efficient use of GA caches, which are now named to be more specific the longer the match