### PR TITLE
chore: set actix web default logging to warn

### DIFF
--- a/sample.env
+++ b/sample.env
@@ -4,4 +4,4 @@ GH_PILOT_WEBHOOK_SECRET=your_webhook_secret
 GH_PILOT_OWNER=default_github_org
 xGH_PILOT_NON_INTERACTIVE=1
 
-RUST_LOG=info,ghp_server=debug
+RUST_LOG=info,ghp_server=debug,actix_server=warn


### PR DESCRIPTION
You still need to actually set the variable, but sample.env is updated with the new recommended default setting